### PR TITLE
RH2023467: Enable FIPS keys export

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -31,6 +31,7 @@ import java.security.SecureRandom;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.List;
+import jdk.internal.misc.SharedSecrets;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
 import static sun.security.provider.SunEntries.createAliases;
 import static sun.security.provider.SunEntries.createAliasesWithOid;
@@ -78,6 +79,10 @@ import static sun.security.provider.SunEntries.createAliasesWithOid;
  */
 
 public final class SunJCE extends Provider {
+
+    private static final boolean systemFipsEnabled =
+            SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
+            .isSystemFipsEnabled();
 
     private static final long serialVersionUID = 6812507587804302833L;
 
@@ -180,249 +185,251 @@ public final class SunJCE extends Provider {
 
         // reuse attribute map and reset before each reuse
         HashMap<String, String> attrs = new HashMap<>(3);
-        attrs.put("SupportedModes", "ECB");
-        attrs.put("SupportedPaddings", "NOPADDING|PKCS1PADDING|OAEPPADDING"
-                + "|OAEPWITHMD5ANDMGF1PADDING"
-                + "|OAEPWITHSHA1ANDMGF1PADDING"
-                + "|OAEPWITHSHA-1ANDMGF1PADDING"
-                + "|OAEPWITHSHA-224ANDMGF1PADDING"
-                + "|OAEPWITHSHA-256ANDMGF1PADDING"
-                + "|OAEPWITHSHA-384ANDMGF1PADDING"
-                + "|OAEPWITHSHA-512ANDMGF1PADDING"
-                + "|OAEPWITHSHA-512/224ANDMGF1PADDING"
-                + "|OAEPWITHSHA-512/256ANDMGF1PADDING");
-        attrs.put("SupportedKeyClasses",
-                "java.security.interfaces.RSAPublicKey" +
-                "|java.security.interfaces.RSAPrivateKey");
-        ps("Cipher", "RSA",
-                "com.sun.crypto.provider.RSACipher", null, attrs);
+        if (!systemFipsEnabled) {
+            attrs.put("SupportedModes", "ECB");
+            attrs.put("SupportedPaddings", "NOPADDING|PKCS1PADDING|OAEPPADDING"
+                    + "|OAEPWITHMD5ANDMGF1PADDING"
+                    + "|OAEPWITHSHA1ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-1ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-224ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-256ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-384ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-512ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-512/224ANDMGF1PADDING"
+                    + "|OAEPWITHSHA-512/256ANDMGF1PADDING");
+            attrs.put("SupportedKeyClasses",
+                    "java.security.interfaces.RSAPublicKey" +
+                    "|java.security.interfaces.RSAPrivateKey");
+            ps("Cipher", "RSA",
+                    "com.sun.crypto.provider.RSACipher", null, attrs);
 
-        // common block cipher modes, pads
-        final String BLOCK_MODES = "ECB|CBC|PCBC|CTR|CTS|CFB|OFB" +
-            "|CFB8|CFB16|CFB24|CFB32|CFB40|CFB48|CFB56|CFB64" +
-            "|OFB8|OFB16|OFB24|OFB32|OFB40|OFB48|OFB56|OFB64";
-        final String BLOCK_MODES128 = BLOCK_MODES +
-            "|GCM|CFB72|CFB80|CFB88|CFB96|CFB104|CFB112|CFB120|CFB128" +
-            "|OFB72|OFB80|OFB88|OFB96|OFB104|OFB112|OFB120|OFB128";
-        final String BLOCK_PADS = "NOPADDING|PKCS5PADDING|ISO10126PADDING";
+            // common block cipher modes, pads
+            final String BLOCK_MODES = "ECB|CBC|PCBC|CTR|CTS|CFB|OFB" +
+                "|CFB8|CFB16|CFB24|CFB32|CFB40|CFB48|CFB56|CFB64" +
+                "|OFB8|OFB16|OFB24|OFB32|OFB40|OFB48|OFB56|OFB64";
+            final String BLOCK_MODES128 = BLOCK_MODES +
+                "|GCM|CFB72|CFB80|CFB88|CFB96|CFB104|CFB112|CFB120|CFB128" +
+                "|OFB72|OFB80|OFB88|OFB96|OFB104|OFB112|OFB120|OFB128";
+            final String BLOCK_PADS = "NOPADDING|PKCS5PADDING|ISO10126PADDING";
 
-        attrs.clear();
-        attrs.put("SupportedModes", BLOCK_MODES);
-        attrs.put("SupportedPaddings", BLOCK_PADS);
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "DES",
-                "com.sun.crypto.provider.DESCipher", null, attrs);
-        ps("Cipher", "DESede", "com.sun.crypto.provider.DESedeCipher",
-                desEdeAliases, attrs);
-        ps("Cipher", "Blowfish",
-                "com.sun.crypto.provider.BlowfishCipher", null, attrs);
+            attrs.clear();
+            attrs.put("SupportedModes", BLOCK_MODES);
+            attrs.put("SupportedPaddings", BLOCK_PADS);
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Cipher", "DES",
+                    "com.sun.crypto.provider.DESCipher", null, attrs);
+            ps("Cipher", "DESede", "com.sun.crypto.provider.DESedeCipher",
+                    desEdeAliases, attrs);
+            ps("Cipher", "Blowfish",
+                    "com.sun.crypto.provider.BlowfishCipher", null, attrs);
 
-        ps("Cipher", "RC2",
-                "com.sun.crypto.provider.RC2Cipher", null, attrs);
+            ps("Cipher", "RC2",
+                    "com.sun.crypto.provider.RC2Cipher", null, attrs);
 
-        attrs.clear();
-        attrs.put("SupportedModes", BLOCK_MODES128);
-        attrs.put("SupportedPaddings", BLOCK_PADS);
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "AES", "com.sun.crypto.provider.AESCipher$General",
-                aesAliases, attrs);
+            attrs.clear();
+            attrs.put("SupportedModes", BLOCK_MODES128);
+            attrs.put("SupportedPaddings", BLOCK_PADS);
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Cipher", "AES", "com.sun.crypto.provider.AESCipher$General",
+                    aesAliases, attrs);
 
-        attrs.clear();
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "AES_128/ECB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_ECB_NoPadding",
-                createAliasesWithOid(aes128Oid+"1"), attrs);
-        ps("Cipher", "AES_128/CBC/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_CBC_NoPadding",
-                createAliasesWithOid(aes128Oid+"2"), attrs);
-        ps("Cipher", "AES_128/OFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_OFB_NoPadding",
-                createAliasesWithOid(aes128Oid+"3"), attrs);
-        ps("Cipher", "AES_128/CFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_CFB_NoPadding",
-                createAliasesWithOid(aes128Oid+"4"), attrs);
-        ps("Cipher", "AES_128/GCM/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_GCM_NoPadding",
-                createAliasesWithOid(aes128Oid+"6"), attrs);
+            attrs.clear();
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Cipher", "AES_128/ECB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES128_ECB_NoPadding",
+                    createAliasesWithOid(aes128Oid+"1"), attrs);
+            ps("Cipher", "AES_128/CBC/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES128_CBC_NoPadding",
+                    createAliasesWithOid(aes128Oid+"2"), attrs);
+            ps("Cipher", "AES_128/OFB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES128_OFB_NoPadding",
+                    createAliasesWithOid(aes128Oid+"3"), attrs);
+            ps("Cipher", "AES_128/CFB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES128_CFB_NoPadding",
+                    createAliasesWithOid(aes128Oid+"4"), attrs);
+            ps("Cipher", "AES_128/GCM/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES128_GCM_NoPadding",
+                    createAliasesWithOid(aes128Oid+"6"), attrs);
 
-        ps("Cipher", "AES_192/ECB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_ECB_NoPadding",
-                createAliasesWithOid(aes192Oid+"1"), attrs);
-        ps("Cipher", "AES_192/CBC/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_CBC_NoPadding",
-                createAliasesWithOid(aes192Oid+"2"), attrs);
-        ps("Cipher", "AES_192/OFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_OFB_NoPadding",
-                createAliasesWithOid(aes192Oid+"3"), attrs);
-        ps("Cipher", "AES_192/CFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_CFB_NoPadding",
-                createAliasesWithOid(aes192Oid+"4"), attrs);
-        ps("Cipher", "AES_192/GCM/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_GCM_NoPadding",
-                createAliasesWithOid(aes192Oid+"6"), attrs);
+            ps("Cipher", "AES_192/ECB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES192_ECB_NoPadding",
+                    createAliasesWithOid(aes192Oid+"1"), attrs);
+            ps("Cipher", "AES_192/CBC/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES192_CBC_NoPadding",
+                    createAliasesWithOid(aes192Oid+"2"), attrs);
+            ps("Cipher", "AES_192/OFB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES192_OFB_NoPadding",
+                    createAliasesWithOid(aes192Oid+"3"), attrs);
+            ps("Cipher", "AES_192/CFB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES192_CFB_NoPadding",
+                    createAliasesWithOid(aes192Oid+"4"), attrs);
+            ps("Cipher", "AES_192/GCM/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES192_GCM_NoPadding",
+                    createAliasesWithOid(aes192Oid+"6"), attrs);
 
-        ps("Cipher", "AES_256/ECB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_ECB_NoPadding",
-                createAliasesWithOid(aes256Oid+"1"), attrs);
-        ps("Cipher", "AES_256/CBC/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_CBC_NoPadding",
-                createAliasesWithOid(aes256Oid+"2"), attrs);
-        ps("Cipher", "AES_256/OFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_OFB_NoPadding",
-                createAliasesWithOid(aes256Oid+"3"), attrs);
-        ps("Cipher", "AES_256/CFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_CFB_NoPadding",
-                createAliasesWithOid(aes256Oid+"4"), attrs);
-        ps("Cipher", "AES_256/GCM/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_GCM_NoPadding",
-                createAliasesWithOid(aes256Oid+"6"), attrs);
+            ps("Cipher", "AES_256/ECB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES256_ECB_NoPadding",
+                    createAliasesWithOid(aes256Oid+"1"), attrs);
+            ps("Cipher", "AES_256/CBC/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES256_CBC_NoPadding",
+                    createAliasesWithOid(aes256Oid+"2"), attrs);
+            ps("Cipher", "AES_256/OFB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES256_OFB_NoPadding",
+                    createAliasesWithOid(aes256Oid+"3"), attrs);
+            ps("Cipher", "AES_256/CFB/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES256_CFB_NoPadding",
+                    createAliasesWithOid(aes256Oid+"4"), attrs);
+            ps("Cipher", "AES_256/GCM/NoPadding",
+                    "com.sun.crypto.provider.AESCipher$AES256_GCM_NoPadding",
+                    createAliasesWithOid(aes256Oid+"6"), attrs);
 
-        attrs.clear();
-        attrs.put("SupportedModes", "CBC");
-        attrs.put("SupportedPaddings", "NOPADDING");
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "DESedeWrap",
-                "com.sun.crypto.provider.DESedeWrapCipher", null, attrs);
+            attrs.clear();
+            attrs.put("SupportedModes", "CBC");
+            attrs.put("SupportedPaddings", "NOPADDING");
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Cipher", "DESedeWrap",
+                    "com.sun.crypto.provider.DESedeWrapCipher", null, attrs);
 
-        attrs.clear();
-        attrs.put("SupportedModes", "ECB");
-        attrs.put("SupportedPaddings", "NOPADDING");
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "ARCFOUR", "com.sun.crypto.provider.ARCFOURCipher",
-                arcFourAliases, attrs);
-        ps("Cipher", "AESWrap", "com.sun.crypto.provider.AESWrapCipher$General",
-                null, attrs);
-        ps("Cipher", "AESWrap_128",
-                "com.sun.crypto.provider.AESWrapCipher$AES128",
-                createAliasesWithOid(aes128Oid+"5"), attrs);
-        ps("Cipher", "AESWrap_192",
-                "com.sun.crypto.provider.AESWrapCipher$AES192",
-                createAliasesWithOid(aes192Oid+"5"), attrs);
-        ps("Cipher", "AESWrap_256",
-                "com.sun.crypto.provider.AESWrapCipher$AES256",
-                createAliasesWithOid(aes256Oid+"5"), attrs);
+            attrs.clear();
+            attrs.put("SupportedModes", "ECB");
+            attrs.put("SupportedPaddings", "NOPADDING");
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Cipher", "ARCFOUR", "com.sun.crypto.provider.ARCFOURCipher",
+                    arcFourAliases, attrs);
+            ps("Cipher", "AESWrap", "com.sun.crypto.provider.AESWrapCipher$General",
+                    null, attrs);
+            ps("Cipher", "AESWrap_128",
+                    "com.sun.crypto.provider.AESWrapCipher$AES128",
+                    createAliasesWithOid(aes128Oid+"5"), attrs);
+            ps("Cipher", "AESWrap_192",
+                    "com.sun.crypto.provider.AESWrapCipher$AES192",
+                    createAliasesWithOid(aes192Oid+"5"), attrs);
+            ps("Cipher", "AESWrap_256",
+                    "com.sun.crypto.provider.AESWrapCipher$AES256",
+                    createAliasesWithOid(aes256Oid+"5"), attrs);
 
-        attrs.clear();
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher",  "ChaCha20",
-                "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Only",
-                null, attrs);
-        ps("Cipher",  "ChaCha20-Poly1305",
-                "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
-                chachaPolyAliases, attrs);
+            attrs.clear();
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Cipher",  "ChaCha20",
+                    "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Only",
+                    null, attrs);
+            ps("Cipher",  "ChaCha20-Poly1305",
+                    "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+                    chachaPolyAliases, attrs);
 
-        // PBES1
-        ps("Cipher", "PBEWithMD5AndDES",
-                "com.sun.crypto.provider.PBEWithMD5AndDESCipher",
-                pkcs5MD5_DESAliases, null);
-        ps("Cipher", "PBEWithMD5AndTripleDES",
-                "com.sun.crypto.provider.PBEWithMD5AndTripleDESCipher",
-                null, null);
-        ps("Cipher", "PBEWithSHA1AndDESede",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndDESede",
-                pkcs12DESedeAliases, null);
-        ps("Cipher", "PBEWithSHA1AndRC2_40",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_40",
-                pkcs12RC2_40Aliases, null);
-        ps("Cipher", "PBEWithSHA1AndRC2_128",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_128",
-                pkcs12RC2_128Aliases, null);
-        ps("Cipher", "PBEWithSHA1AndRC4_40",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_40",
-                pkcs12RC4_40Aliases, null);
+            // PBES1
+            ps("Cipher", "PBEWithMD5AndDES",
+                    "com.sun.crypto.provider.PBEWithMD5AndDESCipher",
+                    pkcs5MD5_DESAliases, null);
+            ps("Cipher", "PBEWithMD5AndTripleDES",
+                    "com.sun.crypto.provider.PBEWithMD5AndTripleDESCipher",
+                    null, null);
+            ps("Cipher", "PBEWithSHA1AndDESede",
+                    "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndDESede",
+                    pkcs12DESedeAliases, null);
+            ps("Cipher", "PBEWithSHA1AndRC2_40",
+                    "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_40",
+                    pkcs12RC2_40Aliases, null);
+            ps("Cipher", "PBEWithSHA1AndRC2_128",
+                    "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_128",
+                    pkcs12RC2_128Aliases, null);
+            ps("Cipher", "PBEWithSHA1AndRC4_40",
+                    "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_40",
+                    pkcs12RC4_40Aliases, null);
 
-        ps("Cipher", "PBEWithSHA1AndRC4_128",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_128",
-                pkcs12RC4_128Aliases, null);
+            ps("Cipher", "PBEWithSHA1AndRC4_128",
+                    "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_128",
+                    pkcs12RC4_128Aliases, null);
 
-        // PBES2
-        ps("Cipher", "PBEWithHmacSHA1AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_128",
-                null, null);
+            // PBES2
+            ps("Cipher", "PBEWithHmacSHA1AndAES_128",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_128",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA224AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_128",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA224AndAES_128",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_128",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA256AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_128",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA256AndAES_128",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_128",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA384AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_128",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA384AndAES_128",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_128",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA512AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_128",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA512AndAES_128",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_128",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA1AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_256",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA1AndAES_256",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_256",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA224AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_256",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA224AndAES_256",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_256",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA256AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_256",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA256AndAES_256",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_256",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA384AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_256",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA384AndAES_256",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_256",
+                    null, null);
 
-        ps("Cipher", "PBEWithHmacSHA512AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_256",
-                null, null);
+            ps("Cipher", "PBEWithHmacSHA512AndAES_256",
+                    "com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_256",
+                    null, null);
 
-        /*
-         * Key(pair) Generator engines
-         */
-        ps("KeyGenerator", "DES",
-                "com.sun.crypto.provider.DESKeyGenerator",
-                null, null);
-        ps("KeyGenerator", "DESede",
-                "com.sun.crypto.provider.DESedeKeyGenerator",
-                desEdeAliases, null);
-        ps("KeyGenerator", "Blowfish",
-                "com.sun.crypto.provider.BlowfishKeyGenerator",
-                null, null);
-        ps("KeyGenerator", "AES",
-                "com.sun.crypto.provider.AESKeyGenerator",
-                aesAliases, null);
-        ps("KeyGenerator", "RC2",
-                "com.sun.crypto.provider.KeyGeneratorCore$RC2KeyGenerator",
-                null, null);
-        ps("KeyGenerator", "ARCFOUR",
-                "com.sun.crypto.provider.KeyGeneratorCore$ARCFOURKeyGenerator",
-                arcFourAliases, null);
-        ps("KeyGenerator", "ChaCha20",
-                "com.sun.crypto.provider.KeyGeneratorCore$ChaCha20KeyGenerator",
-                null, null);
-        ps("KeyGenerator", "HmacMD5",
-                "com.sun.crypto.provider.HmacMD5KeyGenerator",
-                null, null);
+            /*
+             * Key(pair) Generator engines
+             */
+            ps("KeyGenerator", "DES",
+                    "com.sun.crypto.provider.DESKeyGenerator",
+                    null, null);
+            ps("KeyGenerator", "DESede",
+                    "com.sun.crypto.provider.DESedeKeyGenerator",
+                    desEdeAliases, null);
+            ps("KeyGenerator", "Blowfish",
+                    "com.sun.crypto.provider.BlowfishKeyGenerator",
+                    null, null);
+            ps("KeyGenerator", "AES",
+                    "com.sun.crypto.provider.AESKeyGenerator",
+                    aesAliases, null);
+            ps("KeyGenerator", "RC2",
+                    "com.sun.crypto.provider.KeyGeneratorCore$RC2KeyGenerator",
+                    null, null);
+            ps("KeyGenerator", "ARCFOUR",
+                    "com.sun.crypto.provider.KeyGeneratorCore$ARCFOURKeyGenerator",
+                    arcFourAliases, null);
+            ps("KeyGenerator", "ChaCha20",
+                    "com.sun.crypto.provider.KeyGeneratorCore$ChaCha20KeyGenerator",
+                    null, null);
+            ps("KeyGenerator", "HmacMD5",
+                    "com.sun.crypto.provider.HmacMD5KeyGenerator",
+                    null, null);
 
-        ps("KeyGenerator", "HmacSHA1",
-                "com.sun.crypto.provider.HmacSHA1KeyGenerator",
-                macSHA1Aliases, null);
-        ps("KeyGenerator", "HmacSHA224",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA224",
-                macSHA224Aliases, null);
-        ps("KeyGenerator", "HmacSHA256",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA256",
-                macSHA256Aliases, null);
-        ps("KeyGenerator", "HmacSHA384",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA384",
-                macSHA384Aliases, null);
-        ps("KeyGenerator", "HmacSHA512",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA512",
-                macSHA512Aliases, null);
+            ps("KeyGenerator", "HmacSHA1",
+                    "com.sun.crypto.provider.HmacSHA1KeyGenerator",
+                    macSHA1Aliases, null);
+            ps("KeyGenerator", "HmacSHA224",
+                    "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA224",
+                    macSHA224Aliases, null);
+            ps("KeyGenerator", "HmacSHA256",
+                    "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA256",
+                    macSHA256Aliases, null);
+            ps("KeyGenerator", "HmacSHA384",
+                    "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA384",
+                    macSHA384Aliases, null);
+            ps("KeyGenerator", "HmacSHA512",
+                    "com.sun.crypto.provider.KeyGeneratorCore$HmacSHA2KG$SHA512",
+                    macSHA512Aliases, null);
 
-        ps("KeyPairGenerator", "DiffieHellman",
-                "com.sun.crypto.provider.DHKeyPairGenerator",
-                diffieHellmanAliases, null);
+            ps("KeyPairGenerator", "DiffieHellman",
+                    "com.sun.crypto.provider.DHKeyPairGenerator",
+                    diffieHellmanAliases, null);
+        }
 
         /*
          * Algorithm parameter generation engines
@@ -431,15 +438,17 @@ public final class SunJCE extends Provider {
                 "DiffieHellman", "com.sun.crypto.provider.DHParameterGenerator",
                 diffieHellmanAliases, null);
 
-        /*
-         * Key Agreement engines
-         */
-        attrs.clear();
-        attrs.put("SupportedKeyClasses", "javax.crypto.interfaces.DHPublicKey" +
-                        "|javax.crypto.interfaces.DHPrivateKey");
-        ps("KeyAgreement", "DiffieHellman",
-                "com.sun.crypto.provider.DHKeyAgreement",
-                diffieHellmanAliases, attrs);
+        if (!systemFipsEnabled) {
+            /*
+             * Key Agreement engines
+             */
+            attrs.clear();
+            attrs.put("SupportedKeyClasses", "javax.crypto.interfaces.DHPublicKey" +
+                            "|javax.crypto.interfaces.DHPrivateKey");
+            ps("KeyAgreement", "DiffieHellman",
+                    "com.sun.crypto.provider.DHKeyAgreement",
+                    diffieHellmanAliases, attrs);
+        }
 
         /*
          * Algorithm Parameter engines
@@ -644,119 +653,121 @@ public final class SunJCE extends Provider {
                 "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256",
                 null, null);
 
-        // PBKDF2
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA1",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
-                pkcs5PBKDF2Aliases, null);
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA224",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA224",
-                null, null);
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA256",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
-                null, null);
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA384",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA384",
-                null, null);
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA512",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA512",
-                null, null);
+        if (!systemFipsEnabled) {
+            // PBKDF2
+            ps("SecretKeyFactory", "PBKDF2WithHmacSHA1",
+                    "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
+                    pkcs5PBKDF2Aliases, null);
+            ps("SecretKeyFactory", "PBKDF2WithHmacSHA224",
+                    "com.sun.crypto.provider.PBKDF2Core$HmacSHA224",
+                    null, null);
+            ps("SecretKeyFactory", "PBKDF2WithHmacSHA256",
+                    "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
+                    null, null);
+            ps("SecretKeyFactory", "PBKDF2WithHmacSHA384",
+                    "com.sun.crypto.provider.PBKDF2Core$HmacSHA384",
+                    null, null);
+            ps("SecretKeyFactory", "PBKDF2WithHmacSHA512",
+                    "com.sun.crypto.provider.PBKDF2Core$HmacSHA512",
+                    null, null);
 
-        /*
-         * MAC
-         */
-        attrs.clear();
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Mac", "HmacMD5", "com.sun.crypto.provider.HmacMD5", null, attrs);
-        ps("Mac", "HmacSHA1", "com.sun.crypto.provider.HmacSHA1",
-                macSHA1Aliases, attrs);
-        ps("Mac", "HmacSHA224", "com.sun.crypto.provider.HmacCore$HmacSHA224",
-                macSHA224Aliases, attrs);
-        ps("Mac", "HmacSHA256", "com.sun.crypto.provider.HmacCore$HmacSHA256",
-                macSHA256Aliases, attrs);
-        ps("Mac", "HmacSHA384", "com.sun.crypto.provider.HmacCore$HmacSHA384",
-                macSHA384Aliases, attrs);
-        ps("Mac", "HmacSHA512", "com.sun.crypto.provider.HmacCore$HmacSHA512",
-                macSHA512Aliases, attrs);
-        // TODO: aliases with OIDs
-        ps("Mac", "HmacSHA512/224",
-                "com.sun.crypto.provider.HmacCore$HmacSHA512_224",
-                null, attrs);
-        ps("Mac", "HmacSHA512/256",
-                "com.sun.crypto.provider.HmacCore$HmacSHA512_256",
-                null, attrs);
-        ps("Mac", "HmacPBESHA1",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA1",
-                null, attrs);
-        ps("Mac", "HmacPBESHA224",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA224",
-                null, attrs);
-        ps("Mac", "HmacPBESHA256",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA256",
-                null, attrs);
-        ps("Mac", "HmacPBESHA384",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA384",
-                null, attrs);
-        ps("Mac", "HmacPBESHA512",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512",
-                null, attrs);
-        ps("Mac", "HmacPBESHA512/224",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_224",
-                null, attrs);
-        ps("Mac", "HmacPBESHA512/256",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_256",
-                null, attrs);
+            /*
+             * MAC
+             */
+            attrs.clear();
+            attrs.put("SupportedKeyFormats", "RAW");
+            ps("Mac", "HmacMD5", "com.sun.crypto.provider.HmacMD5", null, attrs);
+            ps("Mac", "HmacSHA1", "com.sun.crypto.provider.HmacSHA1",
+                    macSHA1Aliases, attrs);
+            ps("Mac", "HmacSHA224", "com.sun.crypto.provider.HmacCore$HmacSHA224",
+                    macSHA224Aliases, attrs);
+            ps("Mac", "HmacSHA256", "com.sun.crypto.provider.HmacCore$HmacSHA256",
+                    macSHA256Aliases, attrs);
+            ps("Mac", "HmacSHA384", "com.sun.crypto.provider.HmacCore$HmacSHA384",
+                    macSHA384Aliases, attrs);
+            ps("Mac", "HmacSHA512", "com.sun.crypto.provider.HmacCore$HmacSHA512",
+                    macSHA512Aliases, attrs);
+            // TODO: aliases with OIDs
+            ps("Mac", "HmacSHA512/224",
+                    "com.sun.crypto.provider.HmacCore$HmacSHA512_224",
+                    null, attrs);
+            ps("Mac", "HmacSHA512/256",
+                    "com.sun.crypto.provider.HmacCore$HmacSHA512_256",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA1",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA1",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA224",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA224",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA256",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA256",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA384",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA384",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA512",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA512/224",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_224",
+                    null, attrs);
+            ps("Mac", "HmacPBESHA512/256",
+                    "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_256",
+                    null, attrs);
 
 
-        // PBMAC1
-        ps("Mac", "PBEWithHmacSHA1",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA1", null, attrs);
-        ps("Mac", "PBEWithHmacSHA224",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA224", null, attrs);
-        ps("Mac", "PBEWithHmacSHA256",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA256", null, attrs);
-        ps("Mac", "PBEWithHmacSHA384",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA384", null, attrs);
-        ps("Mac", "PBEWithHmacSHA512",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA512", null, attrs);
-        ps("Mac", "SslMacMD5",
-                "com.sun.crypto.provider.SslMacCore$SslMacMD5", null, attrs);
-        ps("Mac", "SslMacSHA1",
-                "com.sun.crypto.provider.SslMacCore$SslMacSHA1", null, attrs);
+            // PBMAC1
+            ps("Mac", "PBEWithHmacSHA1",
+                    "com.sun.crypto.provider.PBMAC1Core$HmacSHA1", null, attrs);
+            ps("Mac", "PBEWithHmacSHA224",
+                    "com.sun.crypto.provider.PBMAC1Core$HmacSHA224", null, attrs);
+            ps("Mac", "PBEWithHmacSHA256",
+                    "com.sun.crypto.provider.PBMAC1Core$HmacSHA256", null, attrs);
+            ps("Mac", "PBEWithHmacSHA384",
+                    "com.sun.crypto.provider.PBMAC1Core$HmacSHA384", null, attrs);
+            ps("Mac", "PBEWithHmacSHA512",
+                    "com.sun.crypto.provider.PBMAC1Core$HmacSHA512", null, attrs);
+            ps("Mac", "SslMacMD5",
+                    "com.sun.crypto.provider.SslMacCore$SslMacMD5", null, attrs);
+            ps("Mac", "SslMacSHA1",
+                    "com.sun.crypto.provider.SslMacCore$SslMacSHA1", null, attrs);
 
-        /*
-         * KeyStore
-         */
-        ps("KeyStore", "JCEKS",
-                "com.sun.crypto.provider.JceKeyStore",
-                null, null);
+            /*
+             * KeyStore
+             */
+            ps("KeyStore", "JCEKS",
+                    "com.sun.crypto.provider.JceKeyStore",
+                    null, null);
 
-        /*
-         * SSL/TLS mechanisms
-         *
-         * These are strictly internal implementations and may
-         * be changed at any time.  These names were chosen
-         * because PKCS11/SunPKCS11 does not yet have TLS1.2
-         * mechanisms, and it will cause calls to come here.
-         */
-        ps("KeyGenerator", "SunTlsPrf",
-                "com.sun.crypto.provider.TlsPrfGenerator$V10",
-                null, null);
-        ps("KeyGenerator", "SunTls12Prf",
-                "com.sun.crypto.provider.TlsPrfGenerator$V12",
-                null, null);
+            /*
+             * SSL/TLS mechanisms
+             *
+             * These are strictly internal implementations and may
+             * be changed at any time.  These names were chosen
+             * because PKCS11/SunPKCS11 does not yet have TLS1.2
+             * mechanisms, and it will cause calls to come here.
+             */
+            ps("KeyGenerator", "SunTlsPrf",
+                    "com.sun.crypto.provider.TlsPrfGenerator$V10",
+                    null, null);
+            ps("KeyGenerator", "SunTls12Prf",
+                    "com.sun.crypto.provider.TlsPrfGenerator$V12",
+                    null, null);
 
-        ps("KeyGenerator", "SunTlsMasterSecret",
-                "com.sun.crypto.provider.TlsMasterSecretGenerator",
-                createAliases("SunTls12MasterSecret",
-                    "SunTlsExtendedMasterSecret"), null);
+            ps("KeyGenerator", "SunTlsMasterSecret",
+                    "com.sun.crypto.provider.TlsMasterSecretGenerator",
+                    createAliases("SunTls12MasterSecret",
+                        "SunTlsExtendedMasterSecret"), null);
 
-        ps("KeyGenerator", "SunTlsKeyMaterial",
-                "com.sun.crypto.provider.TlsKeyMaterialGenerator",
-                createAliases("SunTls12KeyMaterial"), null);
+            ps("KeyGenerator", "SunTlsKeyMaterial",
+                    "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+                    createAliases("SunTls12KeyMaterial"), null);
 
-        ps("KeyGenerator", "SunTlsRsaPremasterSecret",
-                "com.sun.crypto.provider.TlsRsaPremasterSecretGenerator",
-                createAliases("SunTls12RsaPremasterSecret"), null);
+            ps("KeyGenerator", "SunTlsRsaPremasterSecret",
+                    "com.sun.crypto.provider.TlsRsaPremasterSecretGenerator",
+                    createAliases("SunTls12RsaPremasterSecret"), null);
+        }
     }
 
     // Return the instance of this class or create one if needed.

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -183,6 +183,7 @@ module java.base {
         java.sql,
         java.xml,
         jdk.crypto.cryptoki,
+        jdk.crypto.ec,
         jdk.jartool,
         jdk.attach,
         jdk.charsets,

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -30,6 +30,7 @@ import java.net.*;
 import java.util.*;
 import java.security.*;
 
+import jdk.internal.misc.SharedSecrets;
 import jdk.internal.util.StaticProperty;
 import sun.security.action.GetPropertyAction;
 
@@ -77,6 +78,10 @@ import sun.security.action.GetPropertyAction;
 
 public final class SunEntries {
 
+    private static final boolean systemFipsEnabled =
+            SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
+            .isSystemFipsEnabled();
+
     // the default algo used by SecureRandom class for new SecureRandom() calls
     public static final String DEF_SECURE_RANDOM_ALGO;
 
@@ -100,136 +105,138 @@ public final class SunEntries {
         // common attribute map
         HashMap<String, String> attrs = new HashMap<>(3);
 
-        /*
-         * SecureRandom engines
-         */
-        attrs.put("ThreadSafe", "true");
-        if (NativePRNG.isAvailable()) {
-            add(p, "SecureRandom", "NativePRNG",
-                    "sun.security.provider.NativePRNG",
-                    null, attrs);
+        if (!systemFipsEnabled) {
+            /*
+             * SecureRandom engines
+             */
+            attrs.put("ThreadSafe", "true");
+            if (NativePRNG.isAvailable()) {
+                add(p, "SecureRandom", "NativePRNG",
+                        "sun.security.provider.NativePRNG",
+                        null, attrs);
+            }
+            if (NativePRNG.Blocking.isAvailable()) {
+                add(p, "SecureRandom", "NativePRNGBlocking",
+                        "sun.security.provider.NativePRNG$Blocking", null, attrs);
+            }
+            if (NativePRNG.NonBlocking.isAvailable()) {
+                add(p, "SecureRandom", "NativePRNGNonBlocking",
+                        "sun.security.provider.NativePRNG$NonBlocking", null, attrs);
+            }
+            attrs.put("ImplementedIn", "Software");
+            add(p, "SecureRandom", "DRBG", "sun.security.provider.DRBG",
+                   null, attrs);
+            add(p, "SecureRandom", "SHA1PRNG",
+                    "sun.security.provider.SecureRandom", null, attrs);
+
+            /*
+             * Signature engines
+             */
+            attrs.clear();
+            String dsaKeyClasses = "java.security.interfaces.DSAPublicKey" +
+                    "|java.security.interfaces.DSAPrivateKey";
+            attrs.put("SupportedKeyClasses", dsaKeyClasses);
+            attrs.put("ImplementedIn", "Software");
+
+            attrs.put("KeySize", "1024"); // for NONE and SHA1 DSA signatures
+
+            add(p, "Signature", "SHA1withDSA",
+                    "sun.security.provider.DSA$SHA1withDSA",
+                    createAliasesWithOid("1.2.840.10040.4.3", "DSA", "DSS",
+                        "SHA/DSA", "SHA-1/DSA", "SHA1/DSA", "SHAwithDSA",
+                        "DSAWithSHA1", "1.3.14.3.2.13", "1.3.14.3.2.27"), attrs);
+            add(p, "Signature", "NONEwithDSA", "sun.security.provider.DSA$RawDSA",
+                    createAliases("RawDSA"), attrs);
+
+            attrs.put("KeySize", "2048"); // for SHA224 and SHA256 DSA signatures
+
+            add(p, "Signature", "SHA224withDSA",
+                    "sun.security.provider.DSA$SHA224withDSA",
+                    createAliasesWithOid("2.16.840.1.101.3.4.3.1"), attrs);
+            add(p, "Signature", "SHA256withDSA",
+                    "sun.security.provider.DSA$SHA256withDSA",
+                    createAliasesWithOid("2.16.840.1.101.3.4.3.2"), attrs);
+
+            attrs.remove("KeySize");
+
+            add(p, "Signature", "SHA1withDSAinP1363Format",
+                    "sun.security.provider.DSA$SHA1withDSAinP1363Format",
+                    null, null);
+            add(p, "Signature", "NONEwithDSAinP1363Format",
+                    "sun.security.provider.DSA$RawDSAinP1363Format",
+                    null, null);
+            add(p, "Signature", "SHA224withDSAinP1363Format",
+                    "sun.security.provider.DSA$SHA224withDSAinP1363Format",
+                    null, null);
+            add(p, "Signature", "SHA256withDSAinP1363Format",
+                    "sun.security.provider.DSA$SHA256withDSAinP1363Format",
+                    null, null);
+
+            /*
+             *  Key Pair Generator engines
+             */
+            attrs.clear();
+            attrs.put("ImplementedIn", "Software");
+            attrs.put("KeySize", "2048"); // for DSA KPG and APG only
+
+            String dsaOid = "1.2.840.10040.4.1";
+            List<String> dsaAliases = createAliasesWithOid(dsaOid, "1.3.14.3.2.12");
+            String dsaKPGImplClass = "sun.security.provider.DSAKeyPairGenerator$";
+            dsaKPGImplClass += (useLegacyDSA? "Legacy" : "Current");
+            add(p, "KeyPairGenerator", "DSA", dsaKPGImplClass, dsaAliases, attrs);
+
+            /*
+             * Algorithm Parameter Generator engines
+             */
+            add(p, "AlgorithmParameterGenerator", "DSA",
+                    "sun.security.provider.DSAParameterGenerator", dsaAliases,
+                    attrs);
+            attrs.remove("KeySize");
+
+            /*
+             * Algorithm Parameter engines
+             */
+            add(p, "AlgorithmParameters", "DSA",
+                    "sun.security.provider.DSAParameters", dsaAliases, attrs);
+
+            /*
+             * Key factories
+             */
+            add(p, "KeyFactory", "DSA", "sun.security.provider.DSAKeyFactory",
+                    dsaAliases, attrs);
+
+            /*
+             * Digest engines
+             */
+            add(p, "MessageDigest", "MD2", "sun.security.provider.MD2", null, attrs);
+            add(p, "MessageDigest", "MD5", "sun.security.provider.MD5", null, attrs);
+            add(p, "MessageDigest", "SHA", "sun.security.provider.SHA",
+                    createAliasesWithOid("1.3.14.3.2.26", "SHA-1", "SHA1"), attrs);
+
+            String sha2BaseOid = "2.16.840.1.101.3.4.2";
+            add(p, "MessageDigest", "SHA-224", "sun.security.provider.SHA2$SHA224",
+                    createAliasesWithOid(sha2BaseOid + ".4"), attrs);
+            add(p, "MessageDigest", "SHA-256", "sun.security.provider.SHA2$SHA256",
+                    createAliasesWithOid(sha2BaseOid + ".1"), attrs);
+            add(p, "MessageDigest", "SHA-384", "sun.security.provider.SHA5$SHA384",
+                    createAliasesWithOid(sha2BaseOid + ".2"), attrs);
+            add(p, "MessageDigest", "SHA-512", "sun.security.provider.SHA5$SHA512",
+                    createAliasesWithOid(sha2BaseOid + ".3"), attrs);
+            add(p, "MessageDigest", "SHA-512/224",
+                    "sun.security.provider.SHA5$SHA512_224",
+                    createAliasesWithOid(sha2BaseOid + ".5"), attrs);
+            add(p, "MessageDigest", "SHA-512/256",
+                    "sun.security.provider.SHA5$SHA512_256",
+                    createAliasesWithOid(sha2BaseOid + ".6"), attrs);
+            add(p, "MessageDigest", "SHA3-224", "sun.security.provider.SHA3$SHA224",
+                    createAliasesWithOid(sha2BaseOid + ".7"), attrs);
+            add(p, "MessageDigest", "SHA3-256", "sun.security.provider.SHA3$SHA256",
+                    createAliasesWithOid(sha2BaseOid + ".8"), attrs);
+            add(p, "MessageDigest", "SHA3-384", "sun.security.provider.SHA3$SHA384",
+                    createAliasesWithOid(sha2BaseOid + ".9"), attrs);
+            add(p, "MessageDigest", "SHA3-512", "sun.security.provider.SHA3$SHA512",
+                    createAliasesWithOid(sha2BaseOid + ".10"), attrs);
         }
-        if (NativePRNG.Blocking.isAvailable()) {
-            add(p, "SecureRandom", "NativePRNGBlocking",
-                    "sun.security.provider.NativePRNG$Blocking", null, attrs);
-        }
-        if (NativePRNG.NonBlocking.isAvailable()) {
-            add(p, "SecureRandom", "NativePRNGNonBlocking",
-                    "sun.security.provider.NativePRNG$NonBlocking", null, attrs);
-        }
-        attrs.put("ImplementedIn", "Software");
-        add(p, "SecureRandom", "DRBG", "sun.security.provider.DRBG",
-               null, attrs);
-        add(p, "SecureRandom", "SHA1PRNG",
-                "sun.security.provider.SecureRandom", null, attrs);
-
-        /*
-         * Signature engines
-         */
-        attrs.clear();
-        String dsaKeyClasses = "java.security.interfaces.DSAPublicKey" +
-                "|java.security.interfaces.DSAPrivateKey";
-        attrs.put("SupportedKeyClasses", dsaKeyClasses);
-        attrs.put("ImplementedIn", "Software");
-
-        attrs.put("KeySize", "1024"); // for NONE and SHA1 DSA signatures
-
-        add(p, "Signature", "SHA1withDSA",
-                "sun.security.provider.DSA$SHA1withDSA",
-                createAliasesWithOid("1.2.840.10040.4.3", "DSA", "DSS",
-                    "SHA/DSA", "SHA-1/DSA", "SHA1/DSA", "SHAwithDSA",
-                    "DSAWithSHA1", "1.3.14.3.2.13", "1.3.14.3.2.27"), attrs);
-        add(p, "Signature", "NONEwithDSA", "sun.security.provider.DSA$RawDSA",
-                createAliases("RawDSA"), attrs);
-
-        attrs.put("KeySize", "2048"); // for SHA224 and SHA256 DSA signatures
-
-        add(p, "Signature", "SHA224withDSA",
-                "sun.security.provider.DSA$SHA224withDSA",
-                createAliasesWithOid("2.16.840.1.101.3.4.3.1"), attrs);
-        add(p, "Signature", "SHA256withDSA",
-                "sun.security.provider.DSA$SHA256withDSA",
-                createAliasesWithOid("2.16.840.1.101.3.4.3.2"), attrs);
-
-        attrs.remove("KeySize");
-
-        add(p, "Signature", "SHA1withDSAinP1363Format",
-                "sun.security.provider.DSA$SHA1withDSAinP1363Format",
-                null, null);
-        add(p, "Signature", "NONEwithDSAinP1363Format",
-                "sun.security.provider.DSA$RawDSAinP1363Format",
-                null, null);
-        add(p, "Signature", "SHA224withDSAinP1363Format",
-                "sun.security.provider.DSA$SHA224withDSAinP1363Format",
-                null, null);
-        add(p, "Signature", "SHA256withDSAinP1363Format",
-                "sun.security.provider.DSA$SHA256withDSAinP1363Format",
-                null, null);
-
-        /*
-         *  Key Pair Generator engines
-         */
-        attrs.clear();
-        attrs.put("ImplementedIn", "Software");
-        attrs.put("KeySize", "2048"); // for DSA KPG and APG only
-
-        String dsaOid = "1.2.840.10040.4.1";
-        List<String> dsaAliases = createAliasesWithOid(dsaOid, "1.3.14.3.2.12");
-        String dsaKPGImplClass = "sun.security.provider.DSAKeyPairGenerator$";
-        dsaKPGImplClass += (useLegacyDSA? "Legacy" : "Current");
-        add(p, "KeyPairGenerator", "DSA", dsaKPGImplClass, dsaAliases, attrs);
-
-        /*
-         * Algorithm Parameter Generator engines
-         */
-        add(p, "AlgorithmParameterGenerator", "DSA",
-                "sun.security.provider.DSAParameterGenerator", dsaAliases,
-                attrs);
-        attrs.remove("KeySize");
-
-        /*
-         * Algorithm Parameter engines
-         */
-        add(p, "AlgorithmParameters", "DSA",
-                "sun.security.provider.DSAParameters", dsaAliases, attrs);
-
-        /*
-         * Key factories
-         */
-        add(p, "KeyFactory", "DSA", "sun.security.provider.DSAKeyFactory",
-                dsaAliases, attrs);
-
-        /*
-         * Digest engines
-         */
-        add(p, "MessageDigest", "MD2", "sun.security.provider.MD2", null, attrs);
-        add(p, "MessageDigest", "MD5", "sun.security.provider.MD5", null, attrs);
-        add(p, "MessageDigest", "SHA", "sun.security.provider.SHA",
-                createAliasesWithOid("1.3.14.3.2.26", "SHA-1", "SHA1"), attrs);
-
-        String sha2BaseOid = "2.16.840.1.101.3.4.2";
-        add(p, "MessageDigest", "SHA-224", "sun.security.provider.SHA2$SHA224",
-                createAliasesWithOid(sha2BaseOid + ".4"), attrs);
-        add(p, "MessageDigest", "SHA-256", "sun.security.provider.SHA2$SHA256",
-                createAliasesWithOid(sha2BaseOid + ".1"), attrs);
-        add(p, "MessageDigest", "SHA-384", "sun.security.provider.SHA5$SHA384",
-                createAliasesWithOid(sha2BaseOid + ".2"), attrs);
-        add(p, "MessageDigest", "SHA-512", "sun.security.provider.SHA5$SHA512",
-                createAliasesWithOid(sha2BaseOid + ".3"), attrs);
-        add(p, "MessageDigest", "SHA-512/224",
-                "sun.security.provider.SHA5$SHA512_224",
-                createAliasesWithOid(sha2BaseOid + ".5"), attrs);
-        add(p, "MessageDigest", "SHA-512/256",
-                "sun.security.provider.SHA5$SHA512_256",
-                createAliasesWithOid(sha2BaseOid + ".6"), attrs);
-        add(p, "MessageDigest", "SHA3-224", "sun.security.provider.SHA3$SHA224",
-                createAliasesWithOid(sha2BaseOid + ".7"), attrs);
-        add(p, "MessageDigest", "SHA3-256", "sun.security.provider.SHA3$SHA256",
-                createAliasesWithOid(sha2BaseOid + ".8"), attrs);
-        add(p, "MessageDigest", "SHA3-384", "sun.security.provider.SHA3$SHA384",
-                createAliasesWithOid(sha2BaseOid + ".9"), attrs);
-        add(p, "MessageDigest", "SHA3-512", "sun.security.provider.SHA3$SHA512",
-                createAliasesWithOid(sha2BaseOid + ".10"), attrs);
 
         /*
          * Certificates

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -105,6 +105,9 @@ public final class SunEntries {
         // common attribute map
         HashMap<String, String> attrs = new HashMap<>(3);
 
+        String dsaOid = "1.2.840.10040.4.1";
+        List<String> dsaAliases = createAliasesWithOid(dsaOid, "1.3.14.3.2.12");
+
         if (!systemFipsEnabled) {
             /*
              * SecureRandom engines
@@ -179,26 +182,26 @@ public final class SunEntries {
             attrs.put("ImplementedIn", "Software");
             attrs.put("KeySize", "2048"); // for DSA KPG and APG only
 
-            String dsaOid = "1.2.840.10040.4.1";
-            List<String> dsaAliases = createAliasesWithOid(dsaOid, "1.3.14.3.2.12");
             String dsaKPGImplClass = "sun.security.provider.DSAKeyPairGenerator$";
             dsaKPGImplClass += (useLegacyDSA? "Legacy" : "Current");
             add(p, "KeyPairGenerator", "DSA", dsaKPGImplClass, dsaAliases, attrs);
+        }
 
-            /*
-             * Algorithm Parameter Generator engines
-             */
-            add(p, "AlgorithmParameterGenerator", "DSA",
-                    "sun.security.provider.DSAParameterGenerator", dsaAliases,
-                    attrs);
-            attrs.remove("KeySize");
+        /*
+         * Algorithm Parameter Generator engines
+         */
+        add(p, "AlgorithmParameterGenerator", "DSA",
+                "sun.security.provider.DSAParameterGenerator", dsaAliases,
+                attrs);
+        attrs.remove("KeySize");
 
-            /*
-             * Algorithm Parameter engines
-             */
-            add(p, "AlgorithmParameters", "DSA",
-                    "sun.security.provider.DSAParameters", dsaAliases, attrs);
+        /*
+         * Algorithm Parameter engines
+         */
+        add(p, "AlgorithmParameters", "DSA",
+                "sun.security.provider.DSAParameters", dsaAliases, attrs);
 
+        if (!systemFipsEnabled) {
             /*
              * Key factories
              */

--- a/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
+++ b/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
@@ -27,6 +27,7 @@ package sun.security.rsa;
 
 import java.util.*;
 import java.security.Provider;
+import jdk.internal.misc.SharedSecrets;
 import static sun.security.provider.SunEntries.createAliasesWithOid;
 
 /**
@@ -35,6 +36,10 @@ import static sun.security.provider.SunEntries.createAliasesWithOid;
  * @author  Andreas Sterbenz
  */
 public final class SunRsaSignEntries {
+
+    private static final boolean systemFipsEnabled =
+            SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
+            .isSystemFipsEnabled();
 
     private void add(Provider p, String type, String algo, String cn,
              List<String> aliases, HashMap<String, String> attrs) {
@@ -56,53 +61,56 @@ public final class SunRsaSignEntries {
 
         // common attribute map
         HashMap<String, String> attrs = new HashMap<>(3);
-        attrs.put("SupportedKeyClasses",
-                "java.security.interfaces.RSAPublicKey" +
-                "|java.security.interfaces.RSAPrivateKey");
+        if (!systemFipsEnabled) {
+            attrs.put("SupportedKeyClasses",
+                    "java.security.interfaces.RSAPublicKey" +
+                    "|java.security.interfaces.RSAPrivateKey");
 
-        add(p, "KeyFactory", "RSA",
-                "sun.security.rsa.RSAKeyFactory$Legacy",
-                rsaAliases, null);
-        add(p, "KeyPairGenerator", "RSA",
-                "sun.security.rsa.RSAKeyPairGenerator$Legacy",
-                rsaAliases, null);
-        add(p, "Signature", "MD2withRSA",
-                "sun.security.rsa.RSASignature$MD2withRSA",
-                createAliasesWithOid(rsaOid + ".2"), attrs);
-        add(p, "Signature", "MD5withRSA",
-                "sun.security.rsa.RSASignature$MD5withRSA",
-                createAliasesWithOid(rsaOid + ".4"), attrs);
-        add(p, "Signature", "SHA1withRSA",
-                "sun.security.rsa.RSASignature$SHA1withRSA",
-                createAliasesWithOid(rsaOid + ".5", sha1withRSAOid2), attrs);
-        add(p, "Signature", "SHA224withRSA",
-                "sun.security.rsa.RSASignature$SHA224withRSA",
-                createAliasesWithOid(rsaOid + ".14"), attrs);
-        add(p, "Signature", "SHA256withRSA",
-                "sun.security.rsa.RSASignature$SHA256withRSA",
-                createAliasesWithOid(rsaOid + ".11"), attrs);
-        add(p, "Signature", "SHA384withRSA",
-                "sun.security.rsa.RSASignature$SHA384withRSA",
-                createAliasesWithOid(rsaOid + ".12"), attrs);
-        add(p, "Signature", "SHA512withRSA",
-                "sun.security.rsa.RSASignature$SHA512withRSA",
-                createAliasesWithOid(rsaOid + ".13"), attrs);
-        add(p, "Signature", "SHA512/224withRSA",
-                "sun.security.rsa.RSASignature$SHA512_224withRSA",
-                createAliasesWithOid(rsaOid + ".15"), attrs);
-        add(p, "Signature", "SHA512/256withRSA",
-                "sun.security.rsa.RSASignature$SHA512_256withRSA",
-                createAliasesWithOid(rsaOid + ".16"), attrs);
+            add(p, "KeyFactory", "RSA",
+                    "sun.security.rsa.RSAKeyFactory$Legacy",
+                    rsaAliases, null);
+            add(p, "KeyPairGenerator", "RSA",
+                    "sun.security.rsa.RSAKeyPairGenerator$Legacy",
+                    rsaAliases, null);
+            add(p, "Signature", "MD2withRSA",
+                    "sun.security.rsa.RSASignature$MD2withRSA",
+                    createAliasesWithOid(rsaOid + ".2"), attrs);
+            add(p, "Signature", "MD5withRSA",
+                    "sun.security.rsa.RSASignature$MD5withRSA",
+                    createAliasesWithOid(rsaOid + ".4"), attrs);
+            add(p, "Signature", "SHA1withRSA",
+                    "sun.security.rsa.RSASignature$SHA1withRSA",
+                    createAliasesWithOid(rsaOid + ".5", sha1withRSAOid2), attrs);
+            add(p, "Signature", "SHA224withRSA",
+                    "sun.security.rsa.RSASignature$SHA224withRSA",
+                    createAliasesWithOid(rsaOid + ".14"), attrs);
+            add(p, "Signature", "SHA256withRSA",
+                    "sun.security.rsa.RSASignature$SHA256withRSA",
+                    createAliasesWithOid(rsaOid + ".11"), attrs);
+            add(p, "Signature", "SHA384withRSA",
+                    "sun.security.rsa.RSASignature$SHA384withRSA",
+                    createAliasesWithOid(rsaOid + ".12"), attrs);
+            add(p, "Signature", "SHA512withRSA",
+                    "sun.security.rsa.RSASignature$SHA512withRSA",
+                    createAliasesWithOid(rsaOid + ".13"), attrs);
+            add(p, "Signature", "SHA512/224withRSA",
+                    "sun.security.rsa.RSASignature$SHA512_224withRSA",
+                    createAliasesWithOid(rsaOid + ".15"), attrs);
+            add(p, "Signature", "SHA512/256withRSA",
+                    "sun.security.rsa.RSASignature$SHA512_256withRSA",
+                    createAliasesWithOid(rsaOid + ".16"), attrs);
 
-        add(p, "KeyFactory", "RSASSA-PSS",
-                "sun.security.rsa.RSAKeyFactory$PSS",
-                rsapssAliases, null);
-        add(p, "KeyPairGenerator", "RSASSA-PSS",
-                "sun.security.rsa.RSAKeyPairGenerator$PSS",
-                rsapssAliases, null);
-        add(p, "Signature", "RSASSA-PSS",
-                "sun.security.rsa.RSAPSSSignature",
-                rsapssAliases, attrs);
+            add(p, "KeyFactory", "RSASSA-PSS",
+                    "sun.security.rsa.RSAKeyFactory$PSS",
+                    rsapssAliases, null);
+            add(p, "KeyPairGenerator", "RSASSA-PSS",
+                    "sun.security.rsa.RSAKeyPairGenerator$PSS",
+                    rsapssAliases, null);
+            add(p, "Signature", "RSASSA-PSS",
+                    "sun.security.rsa.RSAPSSSignature",
+                    rsapssAliases, attrs);
+        }
+
         add(p, "AlgorithmParameters", "RSASSA-PSS",
                 "sun.security.rsa.PSSParameters",
                 rsapssAliases, null);

--- a/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
+++ b/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
@@ -65,10 +65,13 @@ public final class SunRsaSignEntries {
             attrs.put("SupportedKeyClasses",
                     "java.security.interfaces.RSAPublicKey" +
                     "|java.security.interfaces.RSAPrivateKey");
+        }
 
-            add(p, "KeyFactory", "RSA",
-                    "sun.security.rsa.RSAKeyFactory$Legacy",
-                    rsaAliases, null);
+        add(p, "KeyFactory", "RSA",
+                "sun.security.rsa.RSAKeyFactory$Legacy",
+                rsaAliases, null);
+
+        if (!systemFipsEnabled) {
             add(p, "KeyPairGenerator", "RSA",
                     "sun.security.rsa.RSAKeyPairGenerator$Legacy",
                     rsaAliases, null);
@@ -99,10 +102,13 @@ public final class SunRsaSignEntries {
             add(p, "Signature", "SHA512/256withRSA",
                     "sun.security.rsa.RSASignature$SHA512_256withRSA",
                     createAliasesWithOid(rsaOid + ".16"), attrs);
+        }
 
-            add(p, "KeyFactory", "RSASSA-PSS",
-                    "sun.security.rsa.RSAKeyFactory$PSS",
-                    rsapssAliases, null);
+        add(p, "KeyFactory", "RSASSA-PSS",
+                "sun.security.rsa.RSAKeyFactory$PSS",
+                rsapssAliases, null);
+
+        if (!systemFipsEnabled) {
             add(p, "KeyPairGenerator", "RSASSA-PSS",
                     "sun.security.rsa.RSAKeyPairGenerator$PSS",
                     rsapssAliases, null);

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -92,6 +92,8 @@ fips.provider.1=SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
 fips.provider.2=SUN
 fips.provider.3=SunEC
 fips.provider.4=com.sun.net.ssl.internal.ssl.Provider SunPKCS11-NSS-FIPS
+fips.provider.5=SunJCE
+fips.provider.6=SunRsaSign
 
 #
 # A list of preferred providers for specific algorithms. These providers will

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -115,6 +115,7 @@ grant codeBase "jrt:/jdk.charsets" {
 grant codeBase "jrt:/jdk.crypto.ec" {
     permission java.lang.RuntimePermission
                    "accessClassInPackage.sun.security.*";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
     permission java.lang.RuntimePermission "loadLibrary.sunec";
     permission java.security.SecurityPermission "putProviderProperty.SunEC";
     permission java.security.SecurityPermission "clearProviderProperties.SunEC";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -318,8 +318,7 @@ final class FIPSKeyImporter {
                     CKA_PRIVATE_EXPONENT, CKA_PRIME_1, CKA_PRIME_2,
                     CKA_EXPONENT_1, CKA_EXPONENT_2, CKA_COEFFICIENT);
             RSAPrivateKey rsaPKey = RSAPrivateCrtKeyImpl.newKey(
-                    RSAUtil.KeyType.RSA, "PKCS#8", plainExportedKey
-            );
+                    plainExportedKey);
             CK_ATTRIBUTE attr;
             if ((attr = sensitiveAttrs.get(CKA_PRIVATE_EXPONENT)) != null) {
                 attr.pValue = rsaPKey.getPrivateExponent().toByteArray();

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -38,7 +38,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 
 import sun.security.jca.JCAUtil;
@@ -188,34 +187,6 @@ final class FIPSKeyImporter {
                             ECUtil.getECParameterSpec(sunECProvider,
                                     attrsMap.get(CKA_EC_PARAMS).getByteArray()))
                             .getEncoded();
-                    if (token.config.getNssNetscapeDbWorkaround() &&
-                            attrsMap.get(CKA_NETSCAPE_DB) == null) {
-                        attrsMap.put(CKA_NETSCAPE_DB,
-                                new CK_ATTRIBUTE(CKA_NETSCAPE_DB, BigInteger.ZERO));
-                    }
-                } else if (keyType == CKK_DH) {
-                    if (debug != null) {
-                        debug.println("Importing a Diffie-Hellman private key...");
-                    }
-                    if (DHKF == null) {
-                        DHKFLock.lock();
-                        try {
-                            if (DHKF == null) {
-                                DHKF = KeyFactory.getInstance(
-                                        "DH", P11Util.getSunJceProvider());
-                            }
-                        } finally {
-                            DHKFLock.unlock();
-                        }
-                    }
-                    DHPrivateKeySpec spec = new DHPrivateKeySpec
-                            (((v = attrsMap.get(CKA_VALUE).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO,
-                            ((v = attrsMap.get(CKA_PRIME).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO,
-                            ((v = attrsMap.get(CKA_BASE).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO);
-                    keyBytes = DHKF.generatePrivate(spec).getEncoded();
                     if (token.config.getNssNetscapeDbWorkaround() &&
                             attrsMap.get(CKA_NETSCAPE_DB) == null) {
                         attrsMap.put(CKA_NETSCAPE_DB,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -45,6 +45,7 @@ import sun.security.pkcs11.TemplateManager;
 import sun.security.pkcs11.wrapper.CK_ATTRIBUTE;
 import sun.security.pkcs11.wrapper.CK_MECHANISM;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 import sun.security.pkcs11.wrapper.PKCS11Exception;
 import sun.security.rsa.RSAPrivateCrtKeyImpl;
 import sun.security.rsa.RSAUtil;
@@ -70,9 +71,6 @@ final class FIPSKeyImporter {
 
     private static volatile Provider sunECProvider = null;
     private static final ReentrantLock sunECProviderLock = new ReentrantLock();
-
-    private static volatile KeyFactory DHKF = null;
-    private static final ReentrantLock DHKFLock = new ReentrantLock();
 
     static Long importKey(SunPKCS11 sunPKCS11, long hSession, CK_ATTRIBUTE[] attributes)
             throws PKCS11Exception {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -29,11 +29,15 @@ import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.Provider;
 import java.security.Security;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 
@@ -43,6 +47,8 @@ import sun.security.pkcs11.wrapper.CK_ATTRIBUTE;
 import sun.security.pkcs11.wrapper.CK_MECHANISM;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 import sun.security.pkcs11.wrapper.PKCS11Exception;
+import sun.security.rsa.RSAPrivateCrtKeyImpl;
+import sun.security.rsa.RSAUtil;
 import sun.security.rsa.RSAUtil.KeyType;
 import sun.security.util.Debug;
 import sun.security.util.ECUtil;
@@ -52,15 +58,21 @@ final class FIPSKeyImporter {
     private static final Debug debug =
             Debug.getInstance("sunpkcs11");
 
-    private static P11Key importerKey = null;
+    private static volatile P11Key importerKey = null;
+    private static SecretKeySpec exporterKey = null;
+    private static volatile P11Key exporterKeyP11 = null;
     private static final ReentrantLock importerKeyLock = new ReentrantLock();
-    private static CK_MECHANISM importerKeyMechanism = null;
+    // Do not take the exporterKeyLock with the importerKeyLock held.
+    private static final ReentrantLock exporterKeyLock = new ReentrantLock();
+    private static volatile CK_MECHANISM importerKeyMechanism = null;
+    private static volatile CK_MECHANISM exporterKeyMechanism = null;
     private static Cipher importerCipher = null;
+    private static Cipher exporterCipher = null;
 
-    private static Provider sunECProvider = null;
+    private static volatile Provider sunECProvider = null;
     private static final ReentrantLock sunECProviderLock = new ReentrantLock();
 
-    private static KeyFactory DHKF = null;
+    private static volatile KeyFactory DHKF = null;
     private static final ReentrantLock DHKFLock = new ReentrantLock();
 
     static Long importKey(SunPKCS11 sunPKCS11, long hSession, CK_ATTRIBUTE[] attributes)
@@ -84,7 +96,8 @@ final class FIPSKeyImporter {
                             debug.println("Importer Key could not be" +
                                     " generated.");
                         }
-                        throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                        throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                                " fips key importer");
                     }
                     if (debug != null) {
                         debug.println("Importer Key successfully" +
@@ -212,7 +225,8 @@ final class FIPSKeyImporter {
                     if (debug != null) {
                         debug.println("Unrecognized private key type.");
                     }
-                    throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                    throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                            " fips key importer");
                 }
             } else if (keyClass == CKO_SECRET_KEY) {
                 if (debug != null) {
@@ -225,14 +239,19 @@ final class FIPSKeyImporter {
                     debug.println("Private or secret key plain bytes could" +
                             " not be obtained. Import failed.");
                 }
-                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                        " fips key importer");
             }
-            importerCipher.init(Cipher.ENCRYPT_MODE, importerKey,
-                    new IvParameterSpec((byte[])importerKeyMechanism.pParameter),
-                    null);
             attributes = new CK_ATTRIBUTE[attrsMap.size()];
             attrsMap.values().toArray(attributes);
-            encKeyBytes = importerCipher.doFinal(keyBytes);
+            importerKeyLock.lock();
+            try {
+                // No need to reset the cipher object because no multi-part
+                // operations are performed.
+                encKeyBytes = importerCipher.doFinal(keyBytes);
+            } finally {
+                importerKeyLock.unlock();
+            }
             attributes = token.getAttributes(TemplateManager.O_IMPORT,
                     keyClass, keyType, attributes);
             keyID = token.p11.C_UnwrapKey(hSession,
@@ -241,11 +260,153 @@ final class FIPSKeyImporter {
                 debug.println("Imported key ID: " + keyID);
             }
         } catch (Throwable t) {
-            throw new PKCS11Exception(CKR_GENERAL_ERROR);
+            if (t instanceof PKCS11Exception) {
+                throw (PKCS11Exception)t;
+            }
+            throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                    t.getMessage());
         } finally {
             importerKey.releaseKeyID();
         }
         return Long.valueOf(keyID);
+    }
+
+    static void exportKey(SunPKCS11 sunPKCS11, long hSession, long hObject,
+            long keyClass, long keyType, Map<Long, CK_ATTRIBUTE> sensitiveAttrs)
+            throws PKCS11Exception {
+        Token token = sunPKCS11.getToken();
+        if (debug != null) {
+            debug.println("Private or Secret key will be exported in" +
+                    " system FIPS mode.");
+        }
+        if (exporterKeyP11 == null) {
+            try {
+                exporterKeyLock.lock();
+                if (exporterKeyP11 == null) {
+                    if (exporterKeyMechanism == null) {
+                        // Exporter Key creation has not been tried yet. Try it.
+                        createExporterKey(token);
+                    }
+                    if (exporterKeyP11 == null || exporterCipher == null) {
+                        if (debug != null) {
+                            debug.println("Exporter Key could not be" +
+                                    " generated.");
+                        }
+                        throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                                " fips key exporter");
+                    }
+                    if (debug != null) {
+                        debug.println("Exporter Key successfully" +
+                                " generated.");
+                    }
+                }
+            } finally {
+                exporterKeyLock.unlock();
+            }
+        }
+        long exporterKeyID = exporterKeyP11.getKeyID();
+        try {
+            byte[] wrappedKeyBytes = token.p11.C_WrapKey(hSession,
+                    exporterKeyMechanism, exporterKeyID, hObject);
+            byte[] plainExportedKey = null;
+            exporterKeyLock.lock();
+            try {
+                // No need to reset the cipher object because no multi-part
+                // operations are performed.
+                plainExportedKey = exporterCipher.doFinal(wrappedKeyBytes);
+            } finally {
+                exporterKeyLock.unlock();
+            }
+            if (keyClass == CKO_PRIVATE_KEY) {
+                exportPrivateKey(sensitiveAttrs, keyType, plainExportedKey);
+            } else if (keyClass == CKO_SECRET_KEY) {
+                checkAttrs(sensitiveAttrs, "CKO_SECRET_KEY", CKA_VALUE);
+                // CKA_VALUE is guaranteed to be present, since sensitiveAttrs'
+                // size is greater than 0 and no invalid attributes exist
+                sensitiveAttrs.get(CKA_VALUE).pValue = plainExportedKey;
+            } else {
+                throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                        " fips key exporter");
+            }
+        } catch (Throwable t) {
+            if (t instanceof PKCS11Exception) {
+                throw (PKCS11Exception)t;
+            }
+            throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                    t.getMessage());
+        } finally {
+            exporterKeyP11.releaseKeyID();
+        }
+    }
+
+    private static void exportPrivateKey(
+            Map<Long, CK_ATTRIBUTE> sensitiveAttrs, long keyType,
+            byte[] plainExportedKey) throws Throwable {
+        if (keyType == CKK_RSA) {
+            checkAttrs(sensitiveAttrs, "CKO_PRIVATE_KEY CKK_RSA",
+                    CKA_PRIVATE_EXPONENT, CKA_PRIME_1, CKA_PRIME_2,
+                    CKA_EXPONENT_1, CKA_EXPONENT_2, CKA_COEFFICIENT);
+            RSAPrivateKey rsaPKey = RSAPrivateCrtKeyImpl.newKey(
+                    RSAUtil.KeyType.RSA, "PKCS#8", plainExportedKey
+            );
+            CK_ATTRIBUTE attr;
+            if ((attr = sensitiveAttrs.get(CKA_PRIVATE_EXPONENT)) != null) {
+                attr.pValue = rsaPKey.getPrivateExponent().toByteArray();
+            }
+            if (rsaPKey instanceof RSAPrivateCrtKey) {
+                RSAPrivateCrtKey rsaPCrtKey = (RSAPrivateCrtKey) rsaPKey;
+                if ((attr = sensitiveAttrs.get(CKA_PRIME_1)) != null) {
+                    attr.pValue = rsaPCrtKey.getPrimeP().toByteArray();
+                }
+                if ((attr = sensitiveAttrs.get(CKA_PRIME_2)) != null) {
+                    attr.pValue = rsaPCrtKey.getPrimeQ().toByteArray();
+                }
+                if ((attr = sensitiveAttrs.get(CKA_EXPONENT_1)) != null) {
+                    attr.pValue = rsaPCrtKey.getPrimeExponentP().toByteArray();
+                }
+                if ((attr = sensitiveAttrs.get(CKA_EXPONENT_2)) != null) {
+                    attr.pValue = rsaPCrtKey.getPrimeExponentQ().toByteArray();
+                }
+                if ((attr = sensitiveAttrs.get(CKA_COEFFICIENT)) != null) {
+                    attr.pValue = rsaPCrtKey.getCrtCoefficient().toByteArray();
+                }
+            } else {
+                checkAttrs(sensitiveAttrs, "CKO_PRIVATE_KEY CKK_RSA",
+                        CKA_PRIVATE_EXPONENT);
+            }
+        } else if (keyType == CKK_DSA) {
+            checkAttrs(sensitiveAttrs, "CKO_PRIVATE_KEY CKK_DSA", CKA_VALUE);
+            // CKA_VALUE is guaranteed to be present, since sensitiveAttrs'
+            // size is greater than 0 and no invalid attributes exist
+            sensitiveAttrs.get(CKA_VALUE).pValue =
+                    new sun.security.provider.DSAPrivateKey(plainExportedKey)
+                            .getX().toByteArray();
+        } else if (keyType == CKK_EC) {
+            checkAttrs(sensitiveAttrs, "CKO_PRIVATE_KEY CKK_EC", CKA_VALUE);
+            // CKA_VALUE is guaranteed to be present, since sensitiveAttrs'
+            // size is greater than 0 and no invalid attributes exist
+            sensitiveAttrs.get(CKA_VALUE).pValue =
+                    ECUtil.decodePKCS8ECPrivateKey(plainExportedKey)
+                            .getS().toByteArray();
+        } else {
+            throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                    " unsupported CKO_PRIVATE_KEY key type: " + keyType);
+        }
+    }
+
+    private static void checkAttrs(Map<Long, CK_ATTRIBUTE> sensitiveAttrs,
+                                     String keyName, long... validAttrs)
+            throws PKCS11Exception {
+        int sensitiveAttrsCount = sensitiveAttrs.size();
+        if (sensitiveAttrsCount <= validAttrs.length) {
+            int validAttrsCount = 0;
+            for (long validAttr : validAttrs) {
+                if (sensitiveAttrs.containsKey(validAttr)) validAttrsCount++;
+            }
+            if (validAttrsCount == sensitiveAttrsCount) return;
+        }
+        throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                " invalid attribute types for a " + keyName + " key object");
     }
 
     private static void createImporterKey(Token token) {
@@ -278,6 +439,9 @@ final class FIPSKeyImporter {
             }
             if (importerKey != null) {
                 importerCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+                importerCipher.init(Cipher.ENCRYPT_MODE, importerKey,
+                        new IvParameterSpec(
+                                (byte[])importerKeyMechanism.pParameter), null);
             }
         } catch (Throwable t) {
             // best effort
@@ -285,6 +449,41 @@ final class FIPSKeyImporter {
             importerCipher = null;
             // importerKeyMechanism value is kept initialized to indicate that
             // Importer Key creation has been tried and failed.
+            if (debug != null) {
+                debug.println("Error generating the Importer Key");
+            }
+        }
+    }
+
+    private static void createExporterKey(Token token) {
+        if (debug != null) {
+            debug.println("Generating Exporter Key...");
+        }
+        byte[] iv = new byte[16];
+        JCAUtil.getSecureRandom().nextBytes(iv);
+        exporterKeyMechanism = new CK_MECHANISM(CKM_AES_CBC_PAD, iv);
+        byte[] exporterKeyRaw = new byte[32];
+        JCAUtil.getSecureRandom().nextBytes(exporterKeyRaw);
+        exporterKey = new SecretKeySpec(exporterKeyRaw, "AES");
+        try {
+            SecretKeyFactory skf = SecretKeyFactory.getInstance("AES");
+            exporterKeyP11 = (P11Key)(skf.translateKey(exporterKey));
+            if (exporterKeyP11 != null) {
+                exporterCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+                exporterCipher.init(Cipher.DECRYPT_MODE, exporterKey,
+                        new IvParameterSpec(
+                                (byte[])exporterKeyMechanism.pParameter), null);
+            }
+        } catch (Throwable t) {
+            // best effort
+            exporterKey = null;
+            exporterKeyP11 = null;
+            exporterCipher = null;
+            // exporterKeyMechanism value is kept initialized to indicate that
+            // Exporter Key creation has been tried and failed.
+            if (debug != null) {
+                debug.println("Error generating the Exporter Key");
+            }
         }
     }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -39,6 +39,7 @@ import sun.nio.ch.DirectBuffer;
 import sun.security.jca.JCAUtil;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * P11 AEAD Cipher implementation class. This class currently supports

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -38,6 +38,7 @@ import sun.nio.ch.DirectBuffer;
 import sun.security.jca.JCAUtil;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * Cipher implementation class. This class currently supports

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -37,7 +37,7 @@ import javax.crypto.*;
 import javax.crypto.interfaces.*;
 import javax.crypto.spec.*;
 
-import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.SharedSecrets;
 
 import sun.security.rsa.RSAUtil.KeyType;
 import sun.security.rsa.RSAPublicKeyImpl;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -383,7 +383,8 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (!plainKeySupportEnabled && (attributes[1].getBoolean() ||
+        boolean exportable = plainKeySupportEnabled && !algorithm.equals("DH");
+        if (!exportable && (attributes[1].getBoolean() ||
                 (attributes[2].getBoolean() == false))) {
             return new P11PrivateKey
                 (session, keyID, algorithm, keyLength, attributes);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -37,6 +37,8 @@ import javax.crypto.*;
 import javax.crypto.interfaces.*;
 import javax.crypto.spec.*;
 
+import jdk.internal.access.SharedSecrets;
+
 import sun.security.rsa.RSAUtil.KeyType;
 import sun.security.rsa.RSAPublicKeyImpl;
 import sun.security.rsa.RSAPrivateCrtKeyImpl;
@@ -68,6 +70,9 @@ import sun.security.jca.JCAUtil;
  * @since   1.5
  */
 abstract class P11Key implements Key, Length {
+
+    private static final boolean plainKeySupportEnabled = SharedSecrets
+            .getJavaSecuritySystemConfiguratorAccess().isPlainKeySupportEnabled();
 
     private static final long serialVersionUID = -2575874101938349339L;
 
@@ -378,7 +383,8 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
+        if (!plainKeySupportEnabled && (attributes[1].getBoolean() ||
+                (attributes[2].getBoolean() == false))) {
             return new P11PrivateKey
                 (session, keyID, algorithm, keyLength, attributes);
         } else {
@@ -460,7 +466,8 @@ abstract class P11Key implements Key, Length {
         }
         public String getFormat() {
             token.ensureValid();
-            if (sensitive || (extractable == false)) {
+            if (!plainKeySupportEnabled &&
+                    (sensitive || (extractable == false))) {
                 return null;
             } else {
                 return "RAW";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,6 +72,7 @@ import static sun.security.pkcs11.P11Util.*;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 import sun.security.rsa.RSAKeyFactory;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -36,6 +36,7 @@ import sun.nio.ch.DirectBuffer;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * MAC implementation class. This class currently supports HMAC using

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -39,7 +39,7 @@ import java.security.spec.PSSParameterSpec;
 import java.security.interfaces.*;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
-
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * RSASSA-PSS Signature implementation class. This class currently supports the

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -42,6 +42,7 @@ import sun.security.rsa.RSAPadding;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 import sun.security.util.KeyUtil;
 
 /**

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -73,20 +73,28 @@ public final class SunPKCS11 extends AuthProvider {
             .getJavaSecuritySystemConfiguratorAccess().isPlainKeySupportEnabled();
 
     private static final MethodHandle fipsImportKey;
+    private static final MethodHandle fipsExportKey;
     static {
         MethodHandle fipsImportKeyTmp = null;
+        MethodHandle fipsExportKeyTmp = null;
         if (plainKeySupportEnabled) {
             try {
                 fipsImportKeyTmp = MethodHandles.lookup().findStatic(
                         FIPSKeyImporter.class, "importKey",
                         MethodType.methodType(Long.class, SunPKCS11.class,
                         long.class, CK_ATTRIBUTE[].class));
+                fipsExportKeyTmp = MethodHandles.lookup().findStatic(
+                        FIPSKeyImporter.class, "exportKey",
+                        MethodType.methodType(void.class, SunPKCS11.class,
+                        long.class, long.class,
+                        long.class, long.class, Map.class));
             } catch (Throwable t) {
-                throw new SecurityException("FIPS key importer initialization" +
-                        " failed", t);
+                throw new SecurityException("FIPS key importer-exporter" +
+                        " initialization failed", t);
             }
         }
         fipsImportKey = fipsImportKeyTmp;
+        fipsExportKey = fipsExportKeyTmp;
     }
 
     private static final long serialVersionUID = -1354835039035306505L;
@@ -347,14 +355,18 @@ public final class SunPKCS11 extends AuthProvider {
             initArgs.flags = CKF_OS_LOCKING_OK;
             PKCS11 tmpPKCS11;
             MethodHandle fipsKeyImporter = null;
+            MethodHandle fipsKeyExporter = null;
             if (plainKeySupportEnabled) {
                 fipsKeyImporter = MethodHandles.insertArguments(
                         fipsImportKey, 0, this);
+                fipsKeyExporter = MethodHandles.insertArguments(
+                        fipsExportKey, 0, this);
             }
             try {
                 tmpPKCS11 = PKCS11.getInstance(
                     library, functionList, initArgs,
-                    config.getOmitInitialize(), fipsKeyImporter);
+                    config.getOmitInitialize(), fipsKeyImporter,
+                    fipsKeyExporter);
             } catch (PKCS11Exception e) {
                 if (debug != null) {
                     debug.println("Multi-threaded initialization failed: " + e);
@@ -370,7 +382,8 @@ public final class SunPKCS11 extends AuthProvider {
                     initArgs.flags = 0;
                 }
                 tmpPKCS11 = PKCS11.getInstance(library,
-                    functionList, initArgs, config.getOmitInitialize(), fipsKeyImporter);
+                    functionList, initArgs, config.getOmitInitialize(), fipsKeyImporter,
+                    fipsKeyExporter);
             }
             p11 = tmpPKCS11;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -56,6 +56,7 @@ import sun.security.pkcs11.Secmod.*;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * PKCS#11 provider main class.

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import sun.security.jca.JCAUtil;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.TemplateManager.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * PKCS#11 token.
@@ -389,7 +390,7 @@ class Token implements Serializable {
                                                 mechanism);
                 mechInfoMap.put(mechanism, result);
             } catch (PKCS11Exception e) {
-                if (e.getErrorCode() != PKCS11Constants.CKR_MECHANISM_INVALID) {
+                if (e.getErrorCode() != CKR_MECHANISM_INVALID) {
                     throw e;
                 } else {
                     mechInfoMap.put(mechanism, INVALID_MECH);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -160,7 +160,7 @@ public class PKCS11 {
            String functionList, CK_C_INITIALIZE_ARGS pInitArgs,
            boolean omitInitialize) throws IOException, PKCS11Exception {
         return getInstance(pkcs11ModulePath, functionList,
-                           pInitArgs, omitInitialize, null);
+                           pInitArgs, omitInitialize, null, null);
     }
 
     public static synchronized PKCS11 getInstance(String pkcs11ModulePath,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -58,6 +58,7 @@ import java.security.PrivilegedAction;
 import sun.security.util.Debug;
 
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * This is the default implementation of the PKCS11 interface. IT connects to

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -50,6 +50,8 @@ package sun.security.pkcs11.wrapper;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.*;
 
 import java.security.AccessController;
@@ -163,25 +165,27 @@ public class PKCS11 {
 
     public static synchronized PKCS11 getInstance(String pkcs11ModulePath,
             String functionList, CK_C_INITIALIZE_ARGS pInitArgs,
-            boolean omitInitialize, MethodHandle fipsKeyImporter)
+            boolean omitInitialize, MethodHandle fipsKeyImporter,
+            MethodHandle fipsKeyExporter)
                     throws IOException, PKCS11Exception {
         // we may only call C_Initialize once per native .so/.dll
         // so keep a cache using the (non-canonicalized!) path
         PKCS11 pkcs11 = moduleMap.get(pkcs11ModulePath);
         if (pkcs11 == null) {
-            boolean nssFipsMode = fipsKeyImporter != null;
+            boolean nssFipsMode = fipsKeyImporter != null &&
+                    fipsKeyExporter != null;
             if ((pInitArgs != null)
                     && ((pInitArgs.flags & CKF_OS_LOCKING_OK) != 0)) {
                 if (nssFipsMode) {
                     pkcs11 = new FIPSPKCS11(pkcs11ModulePath, functionList,
-                            fipsKeyImporter);
+                            fipsKeyImporter, fipsKeyExporter);
                 } else {
                     pkcs11 = new PKCS11(pkcs11ModulePath, functionList);
                 }
             } else {
                 if (nssFipsMode) {
                     pkcs11 = new SynchronizedFIPSPKCS11(pkcs11ModulePath,
-                            functionList, fipsKeyImporter);
+                            functionList, fipsKeyImporter, fipsKeyExporter);
                 } else {
                     pkcs11 = new SynchronizedPKCS11(pkcs11ModulePath, functionList);
                 }
@@ -1940,13 +1944,29 @@ static class SynchronizedPKCS11 extends PKCS11 {
 // is enabled.
 static class FIPSPKCS11 extends PKCS11 {
     private MethodHandle fipsKeyImporter;
+    private MethodHandle fipsKeyExporter;
+    private MethodHandle hC_GetAttributeValue;
     FIPSPKCS11(String pkcs11ModulePath, String functionListName,
-            MethodHandle fipsKeyImporter) throws IOException {
+            MethodHandle fipsKeyImporter, MethodHandle fipsKeyExporter)
+                    throws IOException {
         super(pkcs11ModulePath, functionListName);
         this.fipsKeyImporter = fipsKeyImporter;
+        this.fipsKeyExporter = fipsKeyExporter;
+        try {
+            hC_GetAttributeValue = MethodHandles.insertArguments(
+                    MethodHandles.lookup().findSpecial(PKCS11.class,
+                            "C_GetAttributeValue", MethodType.methodType(
+                                    void.class, long.class, long.class,
+                                    CK_ATTRIBUTE[].class),
+                            FIPSPKCS11.class), 0, this);
+        } catch (Throwable t) {
+            throw new RuntimeException(
+                    "sun.security.pkcs11.wrapper.PKCS11" +
+                    "::C_GetAttributeValue method not found.", t);
+        }
     }
 
-    public synchronized long C_CreateObject(long hSession,
+    public long C_CreateObject(long hSession,
             CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
         // Creating sensitive key objects from plain key material in a
         // FIPS-configured NSS Software Token is not allowed. We apply
@@ -1956,20 +1976,46 @@ static class FIPSPKCS11 extends PKCS11 {
                 return ((Long)fipsKeyImporter.invoke(hSession, pTemplate))
                         .longValue();
             } catch (Throwable t) {
-                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                if (t instanceof PKCS11Exception) {
+                    throw (PKCS11Exception)t;
+                }
+                throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                        t.getMessage());
             }
         }
         return super.C_CreateObject(hSession, pTemplate);
+    }
+
+    public void C_GetAttributeValue(long hSession, long hObject,
+            CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        FIPSPKCS11Helper.C_GetAttributeValue(hC_GetAttributeValue,
+                fipsKeyExporter, hSession, hObject, pTemplate);
     }
 }
 
 // FIPSPKCS11 synchronized counterpart.
 static class SynchronizedFIPSPKCS11 extends SynchronizedPKCS11 {
     private MethodHandle fipsKeyImporter;
+    private MethodHandle fipsKeyExporter;
+    private MethodHandle hC_GetAttributeValue;
     SynchronizedFIPSPKCS11(String pkcs11ModulePath, String functionListName,
-            MethodHandle fipsKeyImporter) throws IOException {
+            MethodHandle fipsKeyImporter, MethodHandle fipsKeyExporter)
+                    throws IOException {
         super(pkcs11ModulePath, functionListName);
         this.fipsKeyImporter = fipsKeyImporter;
+        this.fipsKeyExporter = fipsKeyExporter;
+        try {
+            hC_GetAttributeValue = MethodHandles.insertArguments(
+                    MethodHandles.lookup().findSpecial(SynchronizedPKCS11.class,
+                            "C_GetAttributeValue", MethodType.methodType(
+                                    void.class, long.class, long.class,
+                                    CK_ATTRIBUTE[].class),
+                            SynchronizedFIPSPKCS11.class), 0, this);
+        } catch (Throwable t) {
+            throw new RuntimeException(
+                    "sun.security.pkcs11.wrapper.SynchronizedPKCS11" +
+                    "::C_GetAttributeValue method not found.", t);
+        }
     }
 
     public synchronized long C_CreateObject(long hSession,
@@ -1980,10 +2026,20 @@ static class SynchronizedFIPSPKCS11 extends SynchronizedPKCS11 {
                 return ((Long)fipsKeyImporter.invoke(hSession, pTemplate))
                         .longValue();
             } catch (Throwable t) {
-                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                if (t instanceof PKCS11Exception) {
+                    throw (PKCS11Exception)t;
+                }
+                throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                        t.getMessage());
             }
         }
         return super.C_CreateObject(hSession, pTemplate);
+    }
+
+    public synchronized void C_GetAttributeValue(long hSession, long hObject,
+            CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        FIPSPKCS11Helper.C_GetAttributeValue(hC_GetAttributeValue,
+                fipsKeyExporter, hSession, hObject, pTemplate);
     }
 }
 
@@ -1997,6 +2053,79 @@ private static class FIPSPKCS11Helper {
             }
         }
         return false;
+    }
+    static void C_GetAttributeValue(MethodHandle hC_GetAttributeValue,
+            MethodHandle fipsKeyExporter, long hSession, long hObject,
+            CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        Map<Long, CK_ATTRIBUTE> sensitiveAttrs = new HashMap<>();
+        List<CK_ATTRIBUTE> nonSensitiveAttrs = new LinkedList<>();
+        FIPSPKCS11Helper.getAttributesBySensitivity(pTemplate,
+                sensitiveAttrs, nonSensitiveAttrs);
+        try {
+            if (sensitiveAttrs.size() > 0) {
+                long keyClass = -1L;
+                long keyType = -1L;
+                try {
+                    // Secret and private keys have both class and type
+                    // attributes, so we can query them at once.
+                    CK_ATTRIBUTE[] queryAttrs = new CK_ATTRIBUTE[]{
+                            new CK_ATTRIBUTE(CKA_CLASS),
+                            new CK_ATTRIBUTE(CKA_KEY_TYPE),
+                    };
+                    hC_GetAttributeValue.invoke(hSession, hObject, queryAttrs);
+                    keyClass = queryAttrs[0].getLong();
+                    keyType = queryAttrs[1].getLong();
+                } catch (PKCS11Exception e) {
+                    // If the query fails, the object is neither a secret nor a
+                    // private key. As this case won't be handled with the FIPS
+                    // Key Exporter, we keep keyClass initialized to -1L.
+                }
+                if (keyClass == CKO_SECRET_KEY || keyClass == CKO_PRIVATE_KEY) {
+                    fipsKeyExporter.invoke(hSession, hObject, keyClass, keyType,
+                            sensitiveAttrs);
+                    if (nonSensitiveAttrs.size() > 0) {
+                        CK_ATTRIBUTE[] pNonSensitiveAttrs =
+                                new CK_ATTRIBUTE[nonSensitiveAttrs.size()];
+                        int i = 0;
+                        for (CK_ATTRIBUTE nonSensAttr : nonSensitiveAttrs) {
+                            pNonSensitiveAttrs[i++] = nonSensAttr;
+                        }
+                        hC_GetAttributeValue.invoke(hSession, hObject,
+                                pNonSensitiveAttrs);
+                        // libj2pkcs11 allocates new CK_ATTRIBUTE objects, so we
+                        // update the reference on the previous CK_ATTRIBUTEs
+                        i = 0;
+                        for (CK_ATTRIBUTE nonSensAttr : nonSensitiveAttrs) {
+                            nonSensAttr.pValue = pNonSensitiveAttrs[i++].pValue;
+                        }
+                    }
+                    return;
+                }
+            }
+            hC_GetAttributeValue.invoke(hSession, hObject, pTemplate);
+        } catch (Throwable t) {
+            if (t instanceof PKCS11Exception) {
+                throw (PKCS11Exception)t;
+            }
+            throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                    t.getMessage());
+        }
+    }
+    private static void getAttributesBySensitivity(CK_ATTRIBUTE[] pTemplate,
+            Map<Long, CK_ATTRIBUTE> sensitiveAttrs,
+            List<CK_ATTRIBUTE> nonSensitiveAttrs) {
+        for (CK_ATTRIBUTE attr : pTemplate) {
+            long type = attr.type;
+            // Aligned with NSS' sftk_isSensitive in lib/softoken/pkcs11u.c
+            if (type == CKA_VALUE || type == CKA_PRIVATE_EXPONENT ||
+                    type == CKA_PRIME_1 || type == CKA_PRIME_2 ||
+                    type == CKA_EXPONENT_1 || type == CKA_EXPONENT_2 ||
+                    type == CKA_COEFFICIENT) {
+                sensitiveAttrs.put(type, attr);
+            } else {
+                nonSensitiveAttrs.add(attr);
+            }
+        }
     }
 }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -1043,130 +1043,7 @@ public interface PKCS11Constants {
     public static final long  CKF_EXTENSION          = 0x80000000L;
 
     /* Identifies the return value of a Cryptoki function */
-    public static final long  CKR_OK                 = 0x00000000L;
-    public static final long  CKR_CANCEL             = 0x00000001L;
-    public static final long  CKR_HOST_MEMORY        = 0x00000002L;
-    public static final long  CKR_SLOT_ID_INVALID    = 0x00000003L;
-
-    public static final long  CKR_GENERAL_ERROR      = 0x00000005L;
-    public static final long  CKR_FUNCTION_FAILED    = 0x00000006L;
-
-    public static final long  CKR_ARGUMENTS_BAD      = 0x00000007L;
-    public static final long  CKR_NO_EVENT           = 0x00000008L;
-    public static final long  CKR_NEED_TO_CREATE_THREADS
-                                                     = 0x00000009L;
-    public static final long  CKR_CANT_LOCK          = 0x0000000AL;
-
-    public static final long  CKR_ATTRIBUTE_READ_ONLY       = 0x00000010L;
-    public static final long  CKR_ATTRIBUTE_SENSITIVE       = 0x00000011L;
-    public static final long  CKR_ATTRIBUTE_TYPE_INVALID    = 0x00000012L;
-    public static final long  CKR_ATTRIBUTE_VALUE_INVALID   = 0x00000013L;
-    public static final long  CKR_ACTION_PROHIBITED         = 0x0000001BL;
-
-    public static final long  CKR_DATA_INVALID              = 0x00000020L;
-    public static final long  CKR_DATA_LEN_RANGE            = 0x00000021L;
-    public static final long  CKR_DEVICE_ERROR              = 0x00000030L;
-    public static final long  CKR_DEVICE_MEMORY             = 0x00000031L;
-    public static final long  CKR_DEVICE_REMOVED            = 0x00000032L;
-    public static final long  CKR_ENCRYPTED_DATA_INVALID    = 0x00000040L;
-    public static final long  CKR_ENCRYPTED_DATA_LEN_RANGE  = 0x00000041L;
-    public static final long  CKR_AEAD_DECRYPT_FAILED       = 0x00000042L;
-    public static final long  CKR_FUNCTION_CANCELED         = 0x00000050L;
-    public static final long  CKR_FUNCTION_NOT_PARALLEL     = 0x00000051L;
-
-    public static final long  CKR_FUNCTION_NOT_SUPPORTED    = 0x00000054L;
-
-    public static final long  CKR_KEY_HANDLE_INVALID        = 0x00000060L;
-
-    public static final long  CKR_KEY_SIZE_RANGE            = 0x00000062L;
-    public static final long  CKR_KEY_TYPE_INCONSISTENT     = 0x00000063L;
-
-    public static final long  CKR_KEY_NOT_NEEDED                 = 0x00000064L;
-    public static final long  CKR_KEY_CHANGED                    = 0x00000065L;
-    public static final long  CKR_KEY_NEEDED                     = 0x00000066L;
-    public static final long  CKR_KEY_INDIGESTIBLE               = 0x00000067L;
-    public static final long  CKR_KEY_FUNCTION_NOT_PERMITTED     = 0x00000068L;
-    public static final long  CKR_KEY_NOT_WRAPPABLE              = 0x00000069L;
-    public static final long  CKR_KEY_UNEXTRACTABLE              = 0x0000006AL;
-
-    public static final long  CKR_MECHANISM_INVALID              = 0x00000070L;
-    public static final long  CKR_MECHANISM_PARAM_INVALID        = 0x00000071L;
-
-    public static final long  CKR_OBJECT_HANDLE_INVALID          = 0x00000082L;
-    public static final long  CKR_OPERATION_ACTIVE               = 0x00000090L;
-    public static final long  CKR_OPERATION_NOT_INITIALIZED      = 0x00000091L;
-    public static final long  CKR_PIN_INCORRECT                  = 0x000000A0L;
-    public static final long  CKR_PIN_INVALID                    = 0x000000A1L;
-    public static final long  CKR_PIN_LEN_RANGE                  = 0x000000A2L;
-
-    public static final long  CKR_PIN_EXPIRED                    = 0x000000A3L;
-    public static final long  CKR_PIN_LOCKED                     = 0x000000A4L;
-
-    public static final long  CKR_SESSION_CLOSED                 = 0x000000B0L;
-    public static final long  CKR_SESSION_COUNT                  = 0x000000B1L;
-    public static final long  CKR_SESSION_HANDLE_INVALID         = 0x000000B3L;
-    public static final long  CKR_SESSION_PARALLEL_NOT_SUPPORTED = 0x000000B4L;
-    public static final long  CKR_SESSION_READ_ONLY              = 0x000000B5L;
-    public static final long  CKR_SESSION_EXISTS                 = 0x000000B6L;
-
-    public static final long  CKR_SESSION_READ_ONLY_EXISTS       = 0x000000B7L;
-    public static final long  CKR_SESSION_READ_WRITE_SO_EXISTS   = 0x000000B8L;
-
-    public static final long  CKR_SIGNATURE_INVALID              = 0x000000C0L;
-    public static final long  CKR_SIGNATURE_LEN_RANGE            = 0x000000C1L;
-    public static final long  CKR_TEMPLATE_INCOMPLETE            = 0x000000D0L;
-    public static final long  CKR_TEMPLATE_INCONSISTENT          = 0x000000D1L;
-    public static final long  CKR_TOKEN_NOT_PRESENT              = 0x000000E0L;
-    public static final long  CKR_TOKEN_NOT_RECOGNIZED           = 0x000000E1L;
-    public static final long  CKR_TOKEN_WRITE_PROTECTED          = 0x000000E2L;
-    public static final long  CKR_UNWRAPPING_KEY_HANDLE_INVALID  = 0x000000F0L;
-    public static final long  CKR_UNWRAPPING_KEY_SIZE_RANGE      = 0x000000F1L;
-    public static final long  CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT
-                                                                 = 0x000000F2L;
-    public static final long  CKR_USER_ALREADY_LOGGED_IN         = 0x00000100L;
-    public static final long  CKR_USER_NOT_LOGGED_IN             = 0x00000101L;
-    public static final long  CKR_USER_PIN_NOT_INITIALIZED       = 0x00000102L;
-    public static final long  CKR_USER_TYPE_INVALID              = 0x00000103L;
-
-    public static final long  CKR_USER_ANOTHER_ALREADY_LOGGED_IN = 0x00000104L;
-    public static final long  CKR_USER_TOO_MANY_TYPES            = 0x00000105L;
-
-    public static final long  CKR_WRAPPED_KEY_INVALID            = 0x00000110L;
-    public static final long  CKR_WRAPPED_KEY_LEN_RANGE          = 0x00000112L;
-    public static final long  CKR_WRAPPING_KEY_HANDLE_INVALID    = 0x00000113L;
-    public static final long  CKR_WRAPPING_KEY_SIZE_RANGE        = 0x00000114L;
-    public static final long  CKR_WRAPPING_KEY_TYPE_INCONSISTENT = 0x00000115L;
-    public static final long  CKR_RANDOM_SEED_NOT_SUPPORTED      = 0x00000120L;
-
-    public static final long  CKR_RANDOM_NO_RNG                  = 0x00000121L;
-
-    public static final long  CKR_DOMAIN_PARAMS_INVALID          = 0x00000130L;
-
-    public static final long  CKR_CURVE_NOT_SUPPORTED            = 0x00000140L;
-
-    public static final long  CKR_BUFFER_TOO_SMALL               = 0x00000150L;
-    public static final long  CKR_SAVED_STATE_INVALID            = 0x00000160L;
-    public static final long  CKR_INFORMATION_SENSITIVE          = 0x00000170L;
-    public static final long  CKR_STATE_UNSAVEABLE               = 0x00000180L;
-
-    public static final long  CKR_CRYPTOKI_NOT_INITIALIZED       = 0x00000190L;
-    public static final long  CKR_CRYPTOKI_ALREADY_INITIALIZED   = 0x00000191L;
-    public static final long  CKR_MUTEX_BAD                      = 0x000001A0L;
-    public static final long  CKR_MUTEX_NOT_LOCKED               = 0x000001A1L;
-
-    public static final long  CKR_NEW_PIN_MODE                   = 0x000001B0L;
-    public static final long  CKR_NEXT_OTP                       = 0x000001B1L;
-
-    public static final long  CKR_EXCEEDED_MAX_ITERATIONS        = 0x000001B5L;
-    public static final long  CKR_FIPS_SELF_TEST_FAILED          = 0x000001B6L;
-    public static final long  CKR_LIBRARY_LOAD_FAILED            = 0x000001B7L;
-    public static final long  CKR_PIN_TOO_WEAK                   = 0x000001B8L;
-    public static final long  CKR_PUBLIC_KEY_INVALID             = 0x000001B9L;
-    public static final long  CKR_FUNCTION_REJECTED              = 0x00000200L;
-    public static final long  CKR_TOKEN_RESOURCE_EXCEEDED        = 0x00000201L;
-    public static final long  CKR_OPERATION_CANCEL_FAILED        = 0x00000202L;
-
-    public static final long  CKR_VENDOR_DEFINED                 = 0x80000000L;
+    // These CKR_xxx constants are stored/defined in PKCS11Exception class
 
     /* Uncomment when actually used
     public static final long  CKF_END_OF_MESSAGE      = 0x00000001L;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -63,229 +63,172 @@ import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
  * @invariants
  */
 public class PKCS11Exception extends Exception {
-    private static final long serialVersionUID = 4877072363729195L;
+    private static final long serialVersionUID = 4077027363729192L;
 
     /**
      * The code of the error which was the reason for this exception.
      */
-    protected long errorCode_;
+    protected long errorCode;
 
-    private static final Map<Long,String> errorMap;
+    protected String errorMsg;
 
-    static {
-        long[] errorCodes = new long[] {
-            CKR_OK,
-            CKR_CANCEL,
-            CKR_HOST_MEMORY,
-            CKR_SLOT_ID_INVALID,
-            CKR_GENERAL_ERROR,
-            CKR_FUNCTION_FAILED,
-            CKR_ARGUMENTS_BAD,
-            CKR_NO_EVENT,
-            CKR_NEED_TO_CREATE_THREADS,
-            CKR_CANT_LOCK,
-            CKR_ATTRIBUTE_READ_ONLY,
-            CKR_ATTRIBUTE_SENSITIVE,
-            CKR_ATTRIBUTE_TYPE_INVALID,
-            CKR_ATTRIBUTE_VALUE_INVALID,
-            CKR_ACTION_PROHIBITED,
-            CKR_DATA_INVALID,
-            CKR_DATA_LEN_RANGE,
-            CKR_DEVICE_ERROR,
-            CKR_DEVICE_MEMORY,
-            CKR_DEVICE_REMOVED,
-            CKR_ENCRYPTED_DATA_INVALID,
-            CKR_ENCRYPTED_DATA_LEN_RANGE,
-            CKR_AEAD_DECRYPT_FAILED,
-            CKR_FUNCTION_CANCELED,
-            CKR_FUNCTION_NOT_PARALLEL,
-            CKR_FUNCTION_NOT_SUPPORTED,
-            CKR_KEY_HANDLE_INVALID,
-            CKR_KEY_SIZE_RANGE,
-            CKR_KEY_TYPE_INCONSISTENT,
-            CKR_KEY_NOT_NEEDED,
-            CKR_KEY_CHANGED,
-            CKR_KEY_NEEDED,
-            CKR_KEY_INDIGESTIBLE,
-            CKR_KEY_FUNCTION_NOT_PERMITTED,
-            CKR_KEY_NOT_WRAPPABLE,
-            CKR_KEY_UNEXTRACTABLE,
-            CKR_MECHANISM_INVALID,
-            CKR_MECHANISM_PARAM_INVALID,
-            CKR_OBJECT_HANDLE_INVALID,
-            CKR_OPERATION_ACTIVE,
-            CKR_OPERATION_NOT_INITIALIZED,
-            CKR_PIN_INCORRECT,
-            CKR_PIN_INVALID,
-            CKR_PIN_LEN_RANGE,
-            CKR_PIN_EXPIRED,
-            CKR_PIN_LOCKED,
-            CKR_SESSION_CLOSED,
-            CKR_SESSION_COUNT,
-            CKR_SESSION_HANDLE_INVALID,
-            CKR_SESSION_PARALLEL_NOT_SUPPORTED,
-            CKR_SESSION_READ_ONLY,
-            CKR_SESSION_EXISTS,
-            CKR_SESSION_READ_ONLY_EXISTS,
-            CKR_SESSION_READ_WRITE_SO_EXISTS,
-            CKR_SIGNATURE_INVALID,
-            CKR_SIGNATURE_LEN_RANGE,
-            CKR_TEMPLATE_INCOMPLETE,
-            CKR_TEMPLATE_INCONSISTENT,
-            CKR_TOKEN_NOT_PRESENT,
-            CKR_TOKEN_NOT_RECOGNIZED,
-            CKR_TOKEN_WRITE_PROTECTED,
-            CKR_UNWRAPPING_KEY_HANDLE_INVALID,
-            CKR_UNWRAPPING_KEY_SIZE_RANGE,
-            CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT,
-            CKR_USER_ALREADY_LOGGED_IN,
-            CKR_USER_NOT_LOGGED_IN,
-            CKR_USER_PIN_NOT_INITIALIZED,
-            CKR_USER_TYPE_INVALID,
-            CKR_USER_ANOTHER_ALREADY_LOGGED_IN,
-            CKR_USER_TOO_MANY_TYPES,
-            CKR_WRAPPED_KEY_INVALID,
-            CKR_WRAPPED_KEY_LEN_RANGE,
-            CKR_WRAPPING_KEY_HANDLE_INVALID,
-            CKR_WRAPPING_KEY_SIZE_RANGE,
-            CKR_WRAPPING_KEY_TYPE_INCONSISTENT,
-            CKR_RANDOM_SEED_NOT_SUPPORTED,
-            CKR_RANDOM_NO_RNG,
-            CKR_DOMAIN_PARAMS_INVALID,
-            CKR_CURVE_NOT_SUPPORTED,
-            CKR_BUFFER_TOO_SMALL,
-            CKR_SAVED_STATE_INVALID,
-            CKR_INFORMATION_SENSITIVE,
-            CKR_STATE_UNSAVEABLE,
-            CKR_CRYPTOKI_NOT_INITIALIZED,
-            CKR_CRYPTOKI_ALREADY_INITIALIZED,
-            CKR_MUTEX_BAD,
-            CKR_MUTEX_NOT_LOCKED,
-            CKR_NEW_PIN_MODE,
-            CKR_NEXT_OTP,
-            CKR_EXCEEDED_MAX_ITERATIONS,
-            CKR_FIPS_SELF_TEST_FAILED,
-            CKR_LIBRARY_LOAD_FAILED,
-            CKR_PIN_TOO_WEAK,
-            CKR_PUBLIC_KEY_INVALID,
-            CKR_FUNCTION_REJECTED,
-            CKR_TOKEN_RESOURCE_EXCEEDED,
-            CKR_OPERATION_CANCEL_FAILED,
-            CKR_VENDOR_DEFINED,
-        };
-        String[] errorMessages = new String[] {
-            "CKR_OK",
-            "CKR_CANCEL",
-            "CKR_HOST_MEMORY",
-            "CKR_SLOT_ID_INVALID",
-            "CKR_GENERAL_ERROR",
-            "CKR_FUNCTION_FAILED",
-            "CKR_ARGUMENTS_BAD",
-            "CKR_NO_EVENT",
-            "CKR_NEED_TO_CREATE_THREADS",
-            "CKR_CANT_LOCK",
-            "CKR_ATTRIBUTE_READ_ONLY",
-            "CKR_ATTRIBUTE_SENSITIVE",
-            "CKR_ATTRIBUTE_TYPE_INVALID",
-            "CKR_ATTRIBUTE_VALUE_INVALID",
-            "CKR_ACTION_PROHIBITED",
-            "CKR_DATA_INVALID",
-            "CKR_DATA_LEN_RANGE",
-            "CKR_DEVICE_ERROR",
-            "CKR_DEVICE_MEMORY",
-            "CKR_DEVICE_REMOVED",
-            "CKR_ENCRYPTED_DATA_INVALID",
-            "CKR_ENCRYPTED_DATA_LEN_RANGE",
-            "CKR_AEAD_DECRYPT_FAILED",
-            "CKR_FUNCTION_CANCELED",
-            "CKR_FUNCTION_NOT_PARALLEL",
-            "CKR_FUNCTION_NOT_SUPPORTED",
-            "CKR_KEY_HANDLE_INVALID",
-            "CKR_KEY_SIZE_RANGE",
-            "CKR_KEY_TYPE_INCONSISTENT",
-            "CKR_KEY_NOT_NEEDED",
-            "CKR_KEY_CHANGED",
-            "CKR_KEY_NEEDED",
-            "CKR_KEY_INDIGESTIBLE",
-            "CKR_KEY_FUNCTION_NOT_PERMITTED",
-            "CKR_KEY_NOT_WRAPPABLE",
-            "CKR_KEY_UNEXTRACTABLE",
-            "CKR_MECHANISM_INVALID",
-            "CKR_MECHANISM_PARAM_INVALID",
-            "CKR_OBJECT_HANDLE_INVALID",
-            "CKR_OPERATION_ACTIVE",
-            "CKR_OPERATION_NOT_INITIALIZED",
-            "CKR_PIN_INCORRECT",
-            "CKR_PIN_INVALID",
-            "CKR_PIN_LEN_RANGE",
-            "CKR_PIN_EXPIRED",
-            "CKR_PIN_LOCKED",
-            "CKR_SESSION_CLOSED",
-            "CKR_SESSION_COUNT",
-            "CKR_SESSION_HANDLE_INVALID",
-            "CKR_SESSION_PARALLEL_NOT_SUPPORTED",
-            "CKR_SESSION_READ_ONLY",
-            "CKR_SESSION_EXISTS",
-            "CKR_SESSION_READ_ONLY_EXISTS",
-            "CKR_SESSION_READ_WRITE_SO_EXISTS",
-            "CKR_SIGNATURE_INVALID",
-            "CKR_SIGNATURE_LEN_RANGE",
-            "CKR_TEMPLATE_INCOMPLETE",
-            "CKR_TEMPLATE_INCONSISTENT",
-            "CKR_TOKEN_NOT_PRESENT",
-            "CKR_TOKEN_NOT_RECOGNIZED",
-            "CKR_TOKEN_WRITE_PROTECTED",
-            "CKR_UNWRAPPING_KEY_HANDLE_INVALID",
-            "CKR_UNWRAPPING_KEY_SIZE_RANGE",
-            "CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT",
-            "CKR_USER_ALREADY_LOGGED_IN",
-            "CKR_USER_NOT_LOGGED_IN",
-            "CKR_USER_PIN_NOT_INITIALIZED",
-            "CKR_USER_TYPE_INVALID",
-            "CKR_USER_ANOTHER_ALREADY_LOGGED_IN",
-            "CKR_USER_TOO_MANY_TYPES",
-            "CKR_WRAPPED_KEY_INVALID",
-            "CKR_WRAPPED_KEY_LEN_RANGE",
-            "CKR_WRAPPING_KEY_HANDLE_INVALID",
-            "CKR_WRAPPING_KEY_SIZE_RANGE",
-            "CKR_WRAPPING_KEY_TYPE_INCONSISTENT",
-            "CKR_RANDOM_SEED_NOT_SUPPORTED",
-            "CKR_RANDOM_NO_RNG",
-            "CKR_DOMAIN_PARAMS_INVALID",
-            "CKR_CURVE_NOT_SUPPORTED",
-            "CKR_BUFFER_TOO_SMALL",
-            "CKR_SAVED_STATE_INVALID",
-            "CKR_INFORMATION_SENSITIVE",
-            "CKR_STATE_UNSAVEABLE",
-            "CKR_CRYPTOKI_NOT_INITIALIZED",
-            "CKR_CRYPTOKI_ALREADY_INITIALIZED",
-            "CKR_MUTEX_BAD",
-            "CKR_MUTEX_NOT_LOCKED",
-            "CKR_NEW_PIN_MODE",
-            "CKR_NEXT_OTP",
-            "CKR_EXCEEDED_MAX_ITERATIONS",
-            "CKR_FIPS_SELF_TEST_FAILED",
-            "CKR_LIBRARY_LOAD_FAILED",
-            "CKR_PIN_TOO_WEAK",
-            "CKR_PUBLIC_KEY_INVALID",
-            "CKR_FUNCTION_REJECTED",
-            "CKR_TOKEN_RESOURCE_EXCEEDED",
-            "CKR_OPERATION_CANCEL_FAILED",
-            "CKR_VENDOR_DEFINED",
-        };
-        errorMap = new HashMap<Long,String>();
-        for (int i = 0; i < errorCodes.length; i++) {
-            errorMap.put(Long.valueOf(errorCodes[i]), errorMessages[i]);
+    public static final long CKR_GENERAL_ERROR = RV.CKR_GENERAL_ERROR.value;
+    public static final long CKR_ATTRIBUTE_TYPE_INVALID =
+            RV.CKR_ATTRIBUTE_TYPE_INVALID.value;
+    public static final long CKR_DATA_LEN_RANGE = RV.CKR_DATA_LEN_RANGE.value;
+    public static final long CKR_ENCRYPTED_DATA_INVALID =
+            RV.CKR_ENCRYPTED_DATA_INVALID.value;
+    public static final long CKR_ENCRYPTED_DATA_LEN_RANGE =
+            RV.CKR_ENCRYPTED_DATA_LEN_RANGE.value;
+    public static final long CKR_MECHANISM_INVALID =
+            RV.CKR_MECHANISM_INVALID.value;
+    public static final long CKR_MECHANISM_PARAM_INVALID =
+            RV.CKR_MECHANISM_PARAM_INVALID.value;
+    public static final long CKR_OPERATION_NOT_INITIALIZED =
+            RV.CKR_OPERATION_NOT_INITIALIZED.value;
+    public static final long CKR_PIN_INCORRECT =
+            RV.CKR_PIN_INCORRECT.value;
+    public static final long CKR_SIGNATURE_INVALID =
+            RV.CKR_SIGNATURE_INVALID.value;
+    public static final long CKR_SIGNATURE_LEN_RANGE =
+            RV.CKR_SIGNATURE_LEN_RANGE.value;
+    public static final long CKR_USER_ALREADY_LOGGED_IN =
+            RV.CKR_USER_ALREADY_LOGGED_IN.value;
+    public static final long CKR_USER_NOT_LOGGED_IN =
+            RV.CKR_USER_NOT_LOGGED_IN.value;
+    public static final long CKR_BUFFER_TOO_SMALL =
+            RV.CKR_BUFFER_TOO_SMALL.value;
+    public static final long CKR_CRYPTOKI_ALREADY_INITIALIZED =
+            RV.CKR_CRYPTOKI_ALREADY_INITIALIZED.value;
+
+    // enum for all PKCS#11 return value
+    static enum RV {
+        CKR_OK(0x00000000L),
+        CKR_CANCEL(0x00000001L),
+        CKR_HOST_MEMORY(0x00000002L),
+        CKR_SLOT_ID_INVALID(0x00000003L),
+        CKR_GENERAL_ERROR(0x00000005L),
+        CKR_FUNCTION_FAILED(0x00000006L),
+        CKR_ARGUMENTS_BAD(0x00000007L),
+        CKR_NO_EVENT(0x00000008L),
+        CKR_NEED_TO_CREATE_THREADS(0x00000009L),
+        CKR_CANT_LOCK(0x0000000AL),
+        CKR_ATTRIBUTE_READ_ONLY(0x00000010L),
+        CKR_ATTRIBUTE_SENSITIVE(0x00000011L),
+        CKR_ATTRIBUTE_TYPE_INVALID(0x00000012L),
+        CKR_ATTRIBUTE_VALUE_INVALID(0x00000013L),
+        CKR_ACTION_PROHIBITED(0x0000001BL),
+        CKR_DATA_INVALID(0x00000020L),
+        CKR_DATA_LEN_RANGE(0x00000021L),
+        CKR_DEVICE_ERROR(0x00000030L),
+        CKR_DEVICE_MEMORY(0x00000031L),
+        CKR_DEVICE_REMOVED(0x00000032L),
+        CKR_ENCRYPTED_DATA_INVALID(0x00000040L),
+        CKR_ENCRYPTED_DATA_LEN_RANGE(0x00000041L),
+        CKR_AEAD_DECRYPT_FAILED(0x00000042L),
+        CKR_FUNCTION_CANCELED(0x00000050L),
+        CKR_FUNCTION_NOT_PARALLEL(0x00000051L),
+        CKR_FUNCTION_NOT_SUPPORTED(0x00000054L),
+        CKR_KEY_HANDLE_INVALID(0x00000060L),
+        CKR_KEY_SIZE_RANGE(0x00000062L),
+        CKR_KEY_TYPE_INCONSISTENT(0x00000063L),
+        CKR_KEY_NOT_NEEDED(0x00000064L),
+        CKR_KEY_CHANGED(0x00000065L),
+        CKR_KEY_NEEDED(0x00000066L),
+        CKR_KEY_INDIGESTIBLE(0x00000067L),
+        CKR_KEY_FUNCTION_NOT_PERMITTED(0x00000068L),
+        CKR_KEY_NOT_WRAPPABLE(0x00000069L),
+        CKR_KEY_UNEXTRACTABLE(0x0000006AL),
+        CKR_MECHANISM_INVALID(0x00000070L),
+        CKR_MECHANISM_PARAM_INVALID(0x00000071L),
+        CKR_OBJECT_HANDLE_INVALID(0x00000082L),
+        CKR_OPERATION_ACTIVE(0x00000090L),
+        CKR_OPERATION_NOT_INITIALIZED(0x00000091L),
+        CKR_PIN_INCORRECT(0x000000A0L),
+        CKR_PIN_INVALID(0x000000A1L),
+        CKR_PIN_LEN_RANGE(0x000000A2L),
+        CKR_PIN_EXPIRED(0x000000A3L),
+        CKR_PIN_LOCKED(0x000000A4L),
+        CKR_SESSION_CLOSED(0x000000B0L),
+        CKR_SESSION_COUNT(0x000000B1L),
+        CKR_SESSION_HANDLE_INVALID(0x000000B3L),
+        CKR_SESSION_PARALLEL_NOT_SUPPORTED(0x000000B4L),
+        CKR_SESSION_READ_ONLY(0x000000B5L),
+        CKR_SESSION_EXISTS(0x000000B6L),
+        CKR_SESSION_READ_ONLY_EXISTS(0x000000B7L),
+        CKR_SESSION_READ_WRITE_SO_EXISTS(0x000000B8L),
+        CKR_SIGNATURE_INVALID(0x000000C0L),
+        CKR_SIGNATURE_LEN_RANGE(0x000000C1L),
+        CKR_TEMPLATE_INCOMPLETE(0x000000D0L),
+        CKR_TEMPLATE_INCONSISTENT(0x000000D1L),
+        CKR_TOKEN_NOT_PRESENT(0x000000E0L),
+        CKR_TOKEN_NOT_RECOGNIZED(0x000000E1L),
+        CKR_TOKEN_WRITE_PROTECTED(0x000000E2L),
+        CKR_UNWRAPPING_KEY_HANDLE_INVALID(0x000000F0L),
+        CKR_UNWRAPPING_KEY_SIZE_RANGE(0x000000F1L),
+        CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT(0x000000F2L),
+        CKR_USER_ALREADY_LOGGED_IN(0x00000100L),
+        CKR_USER_NOT_LOGGED_IN(0x00000101L),
+        CKR_USER_PIN_NOT_INITIALIZED(0x00000102L),
+        CKR_USER_TYPE_INVALID(0x00000103L),
+        CKR_USER_ANOTHER_ALREADY_LOGGED_IN(0x00000104L),
+        CKR_USER_TOO_MANY_TYPES(0x00000105L),
+        CKR_WRAPPED_KEY_INVALID(0x00000110L),
+        CKR_WRAPPED_KEY_LEN_RANGE(0x00000112L),
+        CKR_WRAPPING_KEY_HANDLE_INVALID(0x00000113L),
+        CKR_WRAPPING_KEY_SIZE_RANGE(0x00000114L),
+        CKR_WRAPPING_KEY_TYPE_INCONSISTENT(0x00000115L),
+        CKR_RANDOM_SEED_NOT_SUPPORTED(0x00000120L),
+        CKR_RANDOM_NO_RNG(0x00000121L),
+        CKR_DOMAIN_PARAMS_INVALID(0x00000130L),
+        CKR_CURVE_NOT_SUPPORTED(0x00000140L),
+        CKR_BUFFER_TOO_SMALL(0x00000150L),
+        CKR_SAVED_STATE_INVALID(0x00000160L),
+        CKR_INFORMATION_SENSITIVE(0x00000170L),
+        CKR_STATE_UNSAVEABLE(0x00000180L),
+        CKR_CRYPTOKI_NOT_INITIALIZED(0x00000190L),
+        CKR_CRYPTOKI_ALREADY_INITIALIZED(0x00000191L),
+        CKR_MUTEX_BAD(0x000001A0L),
+        CKR_MUTEX_NOT_LOCKED(0x000001A1L),
+        CKR_NEW_PIN_MODE(0x000001B0L),
+        CKR_NEXT_OTP(0x000001B1L),
+        CKR_EXCEEDED_MAX_ITERATIONS(0x000001B5L),
+        CKR_FIPS_SELF_TEST_FAILED(0x000001B6L),
+        CKR_LIBRARY_LOAD_FAILED(0x000001B7L),
+        CKR_PIN_TOO_WEAK(0x000001B8L),
+        CKR_PUBLIC_KEY_INVALID(0x000001B9L),
+        CKR_FUNCTION_REJECTED(0x00000200L),
+        CKR_TOKEN_RESOURCE_EXCEEDED(0x00000201L),
+        CKR_OPERATION_CANCEL_FAILED(0x00000202L),
+        CKR_VENDOR_DEFINED(0x80000000L);
+
+        private final long value;
+
+        RV(long value) {
+            this.value = value;
         }
+    };
+
+    private static String lookup(long errorCode) {
+        for (RV r : RV.values()) {
+            if (r.value == errorCode) {
+                return r.name();
+            }
+        }
+        // for unknown PKCS11 return values, just use hex as its string
+        return "0x" + Functions.toFullHexString((int)errorCode);
     }
 
-
     /**
-     * Constructor taking the error code as defined for the CKR_* constants
-     * in PKCS#11.
+     * Constructor taking the error code (the CKR_* constants in PKCS#11) and
+     * extra info for error message.
      */
-    public PKCS11Exception(long errorCode) {
-        errorCode_ = errorCode;
+    public PKCS11Exception(long errorCode, String extraInfo) {
+        this.errorCode = errorCode;
+        this.errorMsg = lookup(errorCode);
+        if (extraInfo != null) {
+            this.errorMsg += extraInfo;
+        }
     }
 
     /**
@@ -299,11 +242,7 @@ public class PKCS11Exception extends Exception {
      * @postconditions (result <> null)
      */
     public String getMessage() {
-        String message = errorMap.get(Long.valueOf(errorCode_));
-        if (message == null) {
-            message = "0x" + Functions.toFullHexString((int)errorCode_);
-        }
-        return message;
+        return errorMsg;
     }
 
     /**
@@ -314,7 +253,6 @@ public class PKCS11Exception extends Exception {
      * @postconditions
      */
     public long getErrorCode() {
-        return errorCode_ ;
+        return errorCode;
     }
-
 }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -95,7 +95,7 @@ void destroyLockObject(JNIEnv *env, jobject jLockObject) {
 /*
  * Add the given pkcs11Implementation object to the list of present modules.
  * Attach the given data to the entry. If the given pkcs11Implementation is
- * already in the lsit, just override its old module data with the new one.
+ * already in the list, just override its old module data with the new one.
  * None of the arguments can be NULL. If one of the arguments is NULL, this
  * function does nothing.
  */
@@ -182,27 +182,48 @@ void removeAllModuleEntries(JNIEnv *env) {
 /*
  * function to convert a PKCS#11 return value into a PKCS#11Exception
  *
- * This function generates a PKCS#11Exception with the returnValue as the errorcode
- * if the returnValue is not CKR_OK. The functin returns 0, if the returnValue is
- * CKR_OK. Otherwise, it returns the returnValue as a jLong.
+ * This function generates a PKCS#11Exception with the returnValue as the
+ * errorcode. If the returnValue is not CKR_OK. The function returns 0, if the
+ * returnValue is CKR_OK. Otherwise, it returns the returnValue as a jLong.
  *
- * @param env - used to call JNI funktions and to get the Exception class
+ * @param env - used to call JNI functions and to get the Exception class
  * @param returnValue - of the PKCS#11 function
  */
-jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue)
-{
+jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue) {
+    return ckAssertReturnValueOK2(env, returnValue, NULL);
+}
+
+/*
+ * function to convert a PKCS#11 return value and additional message into a
+ * PKCS#11Exception
+ *
+ * This function generates a PKCS#11Exception with the returnValue as the
+ * errorcode. If the returnValue is not CKR_OK. The function returns 0, if the
+ * returnValue is CKR_OK. Otherwise, it returns the returnValue as a jLong.
+ *
+ * @param env - used to call JNI functions and to get the Exception class
+ * @param returnValue - of the PKCS#11 function
+ * @param msg - additional message for the generated PKCS11Exception
+ */
+jlong ckAssertReturnValueOK2(JNIEnv *env, CK_RV returnValue, const char* msg) {
     jclass jPKCS11ExceptionClass;
     jmethodID jConstructor;
     jthrowable jPKCS11Exception;
     jlong jErrorCode = 0L;
+    jstring jMsg = NULL;
 
     if (returnValue != CKR_OK) {
         jErrorCode = ckULongToJLong(returnValue);
         jPKCS11ExceptionClass = (*env)->FindClass(env, CLASS_PKCS11EXCEPTION);
         if (jPKCS11ExceptionClass != NULL) {
-            jConstructor = (*env)->GetMethodID(env, jPKCS11ExceptionClass, "<init>", "(J)V");
+            jConstructor = (*env)->GetMethodID(env, jPKCS11ExceptionClass,
+                    "<init>", "(JLjava/lang/String;)V");
             if (jConstructor != NULL) {
-                jPKCS11Exception = (jthrowable) (*env)->NewObject(env, jPKCS11ExceptionClass, jConstructor, jErrorCode);
+                if (msg != NULL) {
+                    jMsg = (*env)->NewStringUTF(env, msg);
+                }
+                jPKCS11Exception = (jthrowable) (*env)->NewObject(env,
+                        jPKCS11ExceptionClass, jConstructor, jErrorCode, jMsg);
                 if (jPKCS11Exception != NULL) {
                     (*env)->Throw(env, jPKCS11Exception);
                 }
@@ -210,7 +231,7 @@ jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue)
         }
         (*env)->DeleteLocalRef(env, jPKCS11ExceptionClass);
     }
-    return jErrorCode ;
+    return jErrorCode;
 }
 
 
@@ -253,7 +274,7 @@ void throwIOException(JNIEnv *env, const char *msg)
  * This function simply throws a PKCS#11RuntimeException with the given
  * string as its message.
  *
- * @param env Used to call JNI funktions and to get the Exception class.
+ * @param env Used to call JNI functions and to get the Exception class.
  * @param jmessage The message string of the Exception object.
  */
 void throwPKCS11RuntimeException(JNIEnv *env, const char *message)
@@ -265,7 +286,7 @@ void throwPKCS11RuntimeException(JNIEnv *env, const char *message)
  * This function simply throws a PKCS#11RuntimeException. The message says that
  * the object is not connected to the module.
  *
- * @param env Used to call JNI funktions and to get the Exception class.
+ * @param env Used to call JNI functions and to get the Exception class.
  */
 void throwDisconnectedRuntimeException(JNIEnv *env)
 {
@@ -486,7 +507,7 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
 /*
  * converts a jbooleanArray to a CK_BBOOL array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_BBOOL array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -528,7 +549,7 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
 /*
  * converts a jbyteArray to a CK_BYTE array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_BYTE array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -575,7 +596,7 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
 /*
  * converts a jlongArray to a CK_ULONG array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_ULONG array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -617,7 +638,7 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
 /*
  * converts a jcharArray to a CK_CHAR array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_CHAR array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -659,7 +680,7 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
 /*
  * converts a jcharArray to a CK_UTF8CHAR array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_UTF8CHAR array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -701,7 +722,7 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
 /*
  * converts a jstring to a CK_CHAR array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_CHAR array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -735,7 +756,7 @@ void jStringToCKUTF8CharArray(JNIEnv *env, const jstring jArray, CK_UTF8CHAR_PTR
  * converts a jobjectArray with Java Attributes to a CK_ATTRIBUTE array. The allocated memory
  * has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java Attribute array (template) to convert
  * @param ckpArray - the reference, where the pointer to the new CK_ATTRIBUTE array will be
  *                   stored
@@ -781,7 +802,7 @@ void jAttributeArrayToCKAttributeArray(JNIEnv *env, jobjectArray jArray, CK_ATTR
 /*
  * converts a CK_BYTE array and its length to a jbyteArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_BYTE array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java byte array or NULL if error occurred
@@ -819,7 +840,7 @@ jbyteArray ckByteArrayToJByteArray(JNIEnv *env, const CK_BYTE_PTR ckpArray, CK_U
 /*
  * converts a CK_ULONG array and its length to a jlongArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_ULONG array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java long array
@@ -850,7 +871,7 @@ jlongArray ckULongArrayToJLongArray(JNIEnv *env, const CK_ULONG_PTR ckpArray, CK
 /*
  * converts a CK_CHAR array and its length to a jcharArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_CHAR array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java char array
@@ -881,7 +902,7 @@ jcharArray ckCharArrayToJCharArray(JNIEnv *env, const CK_CHAR_PTR ckpArray, CK_U
 /*
  * converts a CK_UTF8CHAR array and its length to a jcharArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_UTF8CHAR array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java char array
@@ -930,7 +951,7 @@ jcharArray ckUTF8CharArrayToJCharArray(JNIEnv *env, const CK_UTF8CHAR_PTR ckpArr
 /*
  * converts a CK_BBOOL pointer to a Java boolean Object.
  *
- * @param env - used to call JNI funktions to create the new Java object
+ * @param env - used to call JNI functions to create the new Java object
  * @param ckpValue - the pointer to the CK_BBOOL value
  * @return - the new Java boolean object with the boolean value
  */
@@ -954,7 +975,7 @@ jobject ckBBoolPtrToJBooleanObject(JNIEnv *env, const CK_BBOOL *ckpValue)
 /*
  * converts a CK_ULONG pointer to a Java long Object.
  *
- * @param env - used to call JNI funktions to create the new Java object
+ * @param env - used to call JNI functions to create the new Java object
  * @param ckpValue - the pointer to the CK_ULONG value
  * @return - the new Java long object with the long value
  */
@@ -979,7 +1000,7 @@ jobject ckULongPtrToJLongObject(JNIEnv *env, const CK_ULONG_PTR ckpValue)
  * converts a Java boolean object into a pointer to a CK_BBOOL value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Boolean" object to convert
  * @return - the pointer to the new CK_BBOOL value
  */
@@ -1009,7 +1030,7 @@ CK_BBOOL* jBooleanObjectToCKBBoolPtr(JNIEnv *env, jobject jObject)
  * converts a Java byte object into a pointer to a CK_BYTE value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Byte" object to convert
  * @return - the pointer to the new CK_BYTE value
  */
@@ -1038,7 +1059,7 @@ CK_BYTE_PTR jByteObjectToCKBytePtr(JNIEnv *env, jobject jObject)
  * converts a Java integer object into a pointer to a CK_ULONG value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Integer" object to convert
  * @return - the pointer to the new CK_ULONG value
  */
@@ -1067,7 +1088,7 @@ CK_ULONG* jIntegerObjectToCKULongPtr(JNIEnv *env, jobject jObject)
  * converts a Java long object into a pointer to a CK_ULONG value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Long" object to convert
  * @return - the pointer to the new CK_ULONG value
  */
@@ -1097,7 +1118,7 @@ CK_ULONG* jLongObjectToCKULongPtr(JNIEnv *env, jobject jObject)
  * converts a Java char object into a pointer to a CK_CHAR value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Char" object to convert
  * @return - the pointer to the new CK_CHAR value
  */
@@ -1127,7 +1148,7 @@ CK_CHAR_PTR jCharObjectToCKCharPtr(JNIEnv *env, jobject jObject)
  * converts a Java object into a pointer to CK-type or a CK-structure with the length in Bytes.
  * The memory of the returned pointer MUST BE FREED BY CALLER!
  *
- * @param env - used to call JNI funktions to get the Java classes and objects
+ * @param env - used to call JNI functions to get the Java classes and objects
  * @param jObject - the Java object to convert
  * @param ckpLength - pointer to the length (bytes) of the newly-allocated CK-value or CK-structure
  * @return ckpObject - pointer to the newly-allocated CK-value or CK-structure

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -307,6 +307,7 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr);
  */
 
 jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue);
+jlong ckAssertReturnValueOK2(JNIEnv *env, CK_RV returnValue, const char *msg);
 void throwOutOfMemoryError(JNIEnv *env, const char *message);
 void throwNullPointerException(JNIEnv *env, const char *message);
 void throwIOException(JNIEnv *env, const char *message);

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -28,6 +28,7 @@ package sun.security.ec;
 import java.util.*;
 import java.security.*;
 import java.util.regex.Pattern;
+import jdk.internal.misc.SharedSecrets;
 import sun.security.util.CurveDB;
 import sun.security.util.NamedCurve;
 
@@ -52,6 +53,10 @@ import static sun.security.util.SecurityConstants.PROVIDER_VER;
 public final class SunEC extends Provider {
 
     private static final long serialVersionUID = -2279741672933606418L;
+
+    private static final boolean systemFipsEnabled =
+            SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
+            .isSystemFipsEnabled();
 
     // flag indicating whether the full EC implementation is present
     // (when native library is absent then fewer EC algorithms are available)
@@ -233,64 +238,66 @@ public final class SunEC extends Provider {
             return;
         }
 
-        /*
-         * Signature engines
-         */
-        putService(new ProviderService(this, "Signature",
-            "NONEwithECDSA", "sun.security.ec.ECDSASignature$Raw",
-            null, ATTRS));
-        putService(new ProviderService(this, "Signature",
-            "SHA1withECDSA", "sun.security.ec.ECDSASignature$SHA1",
-            new String[] { "1.2.840.10045.4.1", "OID.1.2.840.10045.4.1" },
-            ATTRS));
-        putService(new ProviderService(this, "Signature",
-            "SHA224withECDSA", "sun.security.ec.ECDSASignature$SHA224",
-            new String[] { "1.2.840.10045.4.3.1", "OID.1.2.840.10045.4.3.1"},
-            ATTRS));
-        putService(new ProviderService(this, "Signature",
-            "SHA256withECDSA", "sun.security.ec.ECDSASignature$SHA256",
-            new String[] { "1.2.840.10045.4.3.2", "OID.1.2.840.10045.4.3.2"},
-            ATTRS));
-        putService(new ProviderService(this, "Signature",
-            "SHA384withECDSA", "sun.security.ec.ECDSASignature$SHA384",
-            new String[] { "1.2.840.10045.4.3.3", "OID.1.2.840.10045.4.3.3" },
-            ATTRS));
-        putService(new ProviderService(this, "Signature",
-            "SHA512withECDSA", "sun.security.ec.ECDSASignature$SHA512",
-            new String[] { "1.2.840.10045.4.3.4", "OID.1.2.840.10045.4.3.4" },
-            ATTRS));
+        if (!systemFipsEnabled) {
+            /*
+             * Signature engines
+             */
+            putService(new ProviderService(this, "Signature",
+                "NONEwithECDSA", "sun.security.ec.ECDSASignature$Raw",
+                null, ATTRS));
+            putService(new ProviderService(this, "Signature",
+                "SHA1withECDSA", "sun.security.ec.ECDSASignature$SHA1",
+                new String[] { "1.2.840.10045.4.1", "OID.1.2.840.10045.4.1" },
+                ATTRS));
+            putService(new ProviderService(this, "Signature",
+                "SHA224withECDSA", "sun.security.ec.ECDSASignature$SHA224",
+                new String[] { "1.2.840.10045.4.3.1", "OID.1.2.840.10045.4.3.1"},
+                ATTRS));
+            putService(new ProviderService(this, "Signature",
+                "SHA256withECDSA", "sun.security.ec.ECDSASignature$SHA256",
+                new String[] { "1.2.840.10045.4.3.2", "OID.1.2.840.10045.4.3.2"},
+                ATTRS));
+            putService(new ProviderService(this, "Signature",
+                "SHA384withECDSA", "sun.security.ec.ECDSASignature$SHA384",
+                new String[] { "1.2.840.10045.4.3.3", "OID.1.2.840.10045.4.3.3" },
+                ATTRS));
+            putService(new ProviderService(this, "Signature",
+                "SHA512withECDSA", "sun.security.ec.ECDSASignature$SHA512",
+                new String[] { "1.2.840.10045.4.3.4", "OID.1.2.840.10045.4.3.4" },
+                ATTRS));
 
-        putService(new ProviderService(this, "Signature",
-             "NONEwithECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$RawinP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA1withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA1inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA224withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA224inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA256withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA256inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-            "SHA384withECDSAinP1363Format",
-            "sun.security.ec.ECDSASignature$SHA384inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-            "SHA512withECDSAinP1363Format",
-            "sun.security.ec.ECDSASignature$SHA512inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                 "NONEwithECDSAinP1363Format",
+                 "sun.security.ec.ECDSASignature$RawinP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                 "SHA1withECDSAinP1363Format",
+                 "sun.security.ec.ECDSASignature$SHA1inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                 "SHA224withECDSAinP1363Format",
+                 "sun.security.ec.ECDSASignature$SHA224inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                 "SHA256withECDSAinP1363Format",
+                 "sun.security.ec.ECDSASignature$SHA256inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA384withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA384inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA512withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA512inP1363Format"));
 
-        /*
-         *  Key Pair Generator engine
-         */
-        putService(new ProviderService(this, "KeyPairGenerator",
-            "EC", "sun.security.ec.ECKeyPairGenerator",
-            new String[] { "EllipticCurve" }, ATTRS));
+            /*
+             *  Key Pair Generator engine
+             */
+            putService(new ProviderService(this, "KeyPairGenerator",
+                "EC", "sun.security.ec.ECKeyPairGenerator",
+                new String[] { "EllipticCurve" }, ATTRS));
 
-        /*
-         * Key Agreement engine
-         */
-        putService(new ProviderService(this, "KeyAgreement",
-            "ECDH", "sun.security.ec.ECDHKeyAgreement", null, ATTRS));
+            /*
+             * Key Agreement engine
+             */
+            putService(new ProviderService(this, "KeyAgreement",
+                "ECDH", "sun.security.ec.ECDHKeyAgreement", null, ATTRS));
+        }
     }
 
     private void putXDHEntries() {
@@ -308,23 +315,24 @@ public final class SunEC extends Provider {
             "X448", "sun.security.ec.XDHKeyFactory.X448",
             new String[]{"1.3.101.111", "OID.1.3.101.111"}, ATTRS));
 
-        putService(new ProviderService(this, "KeyPairGenerator",
-            "XDH", "sun.security.ec.XDHKeyPairGenerator", null, ATTRS));
-        putService(new ProviderService(this, "KeyPairGenerator",
-            "X25519", "sun.security.ec.XDHKeyPairGenerator.X25519",
-            new String[]{"1.3.101.110", "OID.1.3.101.110"}, ATTRS));
-        putService(new ProviderService(this, "KeyPairGenerator",
-            "X448", "sun.security.ec.XDHKeyPairGenerator.X448",
-            new String[]{"1.3.101.111", "OID.1.3.101.111"}, ATTRS));
+        if (!systemFipsEnabled) {
+            putService(new ProviderService(this, "KeyPairGenerator",
+                "XDH", "sun.security.ec.XDHKeyPairGenerator", null, ATTRS));
+            putService(new ProviderService(this, "KeyPairGenerator",
+                "X25519", "sun.security.ec.XDHKeyPairGenerator.X25519",
+                new String[]{"1.3.101.110", "OID.1.3.101.110"}, ATTRS));
+            putService(new ProviderService(this, "KeyPairGenerator",
+                "X448", "sun.security.ec.XDHKeyPairGenerator.X448",
+                new String[]{"1.3.101.111", "OID.1.3.101.111"}, ATTRS));
 
-        putService(new ProviderService(this, "KeyAgreement",
-            "XDH", "sun.security.ec.XDHKeyAgreement", null, ATTRS));
-        putService(new ProviderService(this, "KeyAgreement",
-            "X25519", "sun.security.ec.XDHKeyAgreement.X25519",
-            new String[]{"1.3.101.110", "OID.1.3.101.110"}, ATTRS));
-        putService(new ProviderService(this, "KeyAgreement",
-            "X448", "sun.security.ec.XDHKeyAgreement.X448",
-            new String[]{"1.3.101.111", "OID.1.3.101.111"}, ATTRS));
-
+            putService(new ProviderService(this, "KeyAgreement",
+                "XDH", "sun.security.ec.XDHKeyAgreement", null, ATTRS));
+            putService(new ProviderService(this, "KeyAgreement",
+                "X25519", "sun.security.ec.XDHKeyAgreement.X25519",
+                new String[]{"1.3.101.110", "OID.1.3.101.110"}, ATTRS));
+            putService(new ProviderService(this, "KeyAgreement",
+                "X448", "sun.security.ec.XDHKeyAgreement.X448",
+                new String[]{"1.3.101.111", "OID.1.3.101.111"}, ATTRS));
+        }
     }
 }


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk11u/pull/6"))_

| Diff of this PR only | Dependency chain |
|:--------------------:|:----------------:|
| 6afe961de4e757d798e0e38b49cf73e992afa39d...0cb23594fb04a1c7d19f8eba637bdbde0d56740d (including ff26db7a6696e6070c4e9cfc50120d2a967db27a) <br> ff26db7a6696e6070c4e9cfc50120d2a967db27a...0cb23594fb04a1c7d19f8eba637bdbde0d56740d (excluding ff26db7a6696e6070c4e9cfc50120d2a967db27a) | `rh-openjdk:fips` &larr; #1 &larr; #5 &larr; **THIS PR** |

# [RH2023467: Enable the export of keys in plain from the NSS Software Token while in FIPS mode](https://bugzilla.redhat.com/show_bug.cgi?id=2023467)

A backport of rh-openjdk/jdk#1, which also includes rh-openjdk/jdk#14 (a follow-up issue found in the first PR).

NOTE: I've created the branch starting from #5's 6afe961de4e757d798e0e38b49cf73e992afa39d (which is a dependency for certain changes).

### References

* Multi-versions epics
  * [RHELPLAN-112617: Enable the export of keys in plain from the NSS Software Token while in FIPS mode](https://issues.redhat.com/browse/RHELPLAN-112617)
  * [RHELPLAN-127158: Avoid import/export of DH private keys](https://issues.redhat.com/browse/RHELPLAN-127158)
* 17u Bugzilla tickets (for _RHEL 8_)
  * [RH2023467: Enable the export of keys in plain from the NSS Software Token while in FIPS mode [rhel-8, openjdk-17]](https://bugzilla.redhat.com/show_bug.cgi?id=2023467)
  * [RH2104724: Avoid import/export of DH private keys [rhel-8, openjdk-17]](https://bugzilla.redhat.com/show_bug.cgi?id=2104724)
* 11u Bugzilla tickets (for _RHEL 8_)
  * [RH2029653: Enable the export of keys in plain from the NSS Software Token while in FIPS mode [rhel-8, openjdk-11]](https://bugzilla.redhat.com/show_bug.cgi?id=2029653)
  * [RH2133879: Avoid import/export of DH private keys [rhel-8, openjdk-11]](https://bugzilla.redhat.com/show_bug.cgi?id=2133879)

# Pull request creation procedure

1. Create branch starting from 6afe961de4e757d798e0e38b49cf73e992afa39d
   ```sh
   git switch --create=RH2023467 6afe961de4e757d798e0e38b49cf73e992afa39d
   ```
2. Backport [JDK-6676643: Improve current C_GetAttributeValue native implementation](https://bugs.openjdk.org/browse/JDK-6676643) (it applies almost clean except for a trivial conflict in a copyright)
   ```sh
   git fetch https://github.com/openjdk/jdk 7ab6dc83df2e19a57ff0dcdc87598c54cd949a7c
   git cherry-pick --no-commit 7ab6dc83df2e19a57ff0dcdc87598c54cd949a7c

   # Fix trivial copyright dates conflict in PKCS11.java and commit
   sed -i '2,4d;6d' src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
   git commit -a -m "Backport JDK-6676643: Improve current C_GetAttributeValue native implementation

   openjdk/jdk@7ab6dc83df2e19a57ff0dcdc87598c54cd949a7c
   https://bugs.openjdk.org/browse/JDK-6676643
   "
   ```
3. Backport rh-openjdk/jdk@bd324bda437a924e58730cc67c133275e8203780 and rh-openjdk/jdk@7585508387dc78ea6a04154ed3727e6f1fb4c9b4
   ```sh
   git fetch https://github.com/rh-openjdk/jdk bd324bda437a924e58730cc67c133275e8203780 7585508387dc78ea6a04154ed3727e6f1fb4c9b4
   git cherry-pick --edit bd324bda437a924e58730cc67c133275e8203780 7585508387dc78ea6a04154ed3727e6f1fb4c9b4
   ```
4. Fix conflicts (see the _Conflicts_ section below)
5. Execute `git cherry-pick --continue` and edit commit messages to remove the original PR numbers from the `rh-openjdk/jdk` repo, and to add references to the back-ported commit hashes
6. Adapt non-conflicted code to work in 11u (see the _Additional required changes_ section below), commit changes
7. Remove objects from foreign repositories:
   ```sh
   git -c gc.pruneExpire=now -c gc.reflogExpire=now -c gc.reflogExpireUnreachable=now gc
   ```

## Conflicts

* `src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java`
  * Can't remove `errorCode`-only `PKCS11Exception` constructor added in rh-openjdk/jdk@abcd0954643eddbf826d96291d44a143038ab750, because this constructor hadn't been added in 8e0ea91bfb4369195a6ddf92cc772ba31b87a434, since it was still part of upstream 11u code (since 11u doesn't have [JDK-6676643: Improve current C_GetAttributeValue native implementation](https://bugs.openjdk.org/browse/JDK-6676643))
    * Just dropped any change with:
    ```sh
    git restore --ours src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
    git add src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
    ```
* `src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java`
  * Can't cleanly apply the following changes because 11u doesn't have [JDK-8242151: Improve OID mapping and reuse among JDK security providers for aliases registration](https://bugs.openjdk.org/browse/JDK-8242151), manually resolved:
    * Enable `"RSA"` algorithm of the `KeyFactory` service in FIPS (implemented in `sun.security.rsa.RSAKeyFactory$Legacy`)
    * Enable `"RSASSA-PSS"` algorithm of the `KeyFactory` service in FIPS (implemented in `sun.security.rsa.PSSParameters`)

## Additional required changes

Once conflicts were solved, the following changes were required:

* 833d9b39acea4567916d46850bf3a166401ca56a
  * `P11Key.java`: `SharedSecrets` import in 11u has to be of `jdk.internal.misc.SharedSecrets`, and not `jdk.internal.access.SharedSecrets`
  * `PKCS11.java`: changes from 5c8832f0aefa70ce7b7704830ab69b15e42fe57d require passing an extra `null` after rh-openjdk/jdk@bd324bda437a924e58730cc67c133275e8203780 is applied
* c9c517a9f4062305e887f1bc015302775be9403e
  * `FIPSKeyImporter.java`: remove `type` and `format` parameters of `sun.security.rsa.RSAPrivateCrtKeyImpl.newKey()` (added in [JDK-8023980: JCE doesn't provide any class to handle RSA private key in PKCS#1](https://bugs.openjdk.org/browse/JDK-8023980))
* 0cb23594fb04a1c7d19f8eba637bdbde0d56740d
  * Add `import static sun.security.pkcs11.wrapper.PKCS11Exception.*;` to adapt code for introduced openjdk/jdk@7ab6dc83df2e19a57ff0dcdc87598c54cd949a7c backport (ff26db7a6696e6070c4e9cfc50120d2a967db27a)
  * Fix issue noted in [this rh-openjdk/jdk#14 comment](https://github.com/rh-openjdk/jdk/pull/14/files#r1003709626) (addressed in rh-openjdk/jdk#21 for 17u)